### PR TITLE
Fix color parameters

### DIFF
--- a/src/main/java/com/glencoesoftware/omero/ms/image/region/ImageRegionRequestHandler.java
+++ b/src/main/java/com/glencoesoftware/omero/ms/image/region/ImageRegionRequestHandler.java
@@ -255,7 +255,9 @@ public class ImageRegionRequestHandler {
             compressionSrv.setCompressionLevel(
                     imageRegionCtx.compressionQuality);
         }
-        updateSettings(renderer);
+        if (imageRegionCtx.channels != null) {
+            updateSettings(renderer);
+        }
         StopWatch t1 = new Slf4JStopWatch("render");
         try {
             // The actual act of rendering will close the provided pixel buffer

--- a/src/main/java/com/glencoesoftware/omero/ms/image/region/ImageRegionRequestHandler.java
+++ b/src/main/java/com/glencoesoftware/omero/ms/image/region/ImageRegionRequestHandler.java
@@ -376,8 +376,6 @@ public class ImageRegionRequestHandler {
     /**
      * Update settings on the rendering engine based on the current context.
      * @param renderer fully initialized renderer
-     * @param sizeC number of channels
-     * @param ctx OMERO context (group)
      * @throws ServerError
      */
     private void updateSettings(Renderer renderer) throws ServerError {
@@ -423,7 +421,6 @@ public class ImageRegionRequestHandler {
                     }
                 }
             }
-
             idx += 1;
         }
     }

--- a/src/main/java/com/glencoesoftware/omero/ms/image/region/ImageRegionRequestHandler.java
+++ b/src/main/java/com/glencoesoftware/omero/ms/image/region/ImageRegionRequestHandler.java
@@ -423,6 +423,14 @@ public class ImageRegionRequestHandler {
 
             idx += 1;
         }
+    }
+
+    /**
+     * Update model on the rendering engine based on the current context.
+     * @param renderer fully initialized renderer
+     * @throws ServerError
+     */
+    private void updateRenderingModel(Renderer renderer) throws ServerError {
         for (RenderingModel renderingModel : renderingModels) {
             if (imageRegionCtx.m.equals(renderingModel.getValue())) {
                 renderer.setModel(renderingModel);

--- a/src/main/java/com/glencoesoftware/omero/ms/image/region/ImageRegionRequestHandler.java
+++ b/src/main/java/com/glencoesoftware/omero/ms/image/region/ImageRegionRequestHandler.java
@@ -258,6 +258,9 @@ public class ImageRegionRequestHandler {
         if (imageRegionCtx.channels != null) {
             updateSettings(renderer);
         }
+        if (imageRegionCtx.m != null) {
+            updateRenderingModel(renderer);
+        }
         StopWatch t1 = new Slf4JStopWatch("render");
         try {
             // The actual act of rendering will close the provided pixel buffer


### PR DESCRIPTION
This PR resolves the issue with requesting image regions or tiles without color or model parameters. All request below should be handled properly now:
```
* omero-ms-image-region/webgateway/render_image_region/<image_id>/0/0/?region=0,0,1000,1000
* omero-ms-image-region/webgateway/render_image_region/<image_id>/0/0/?region=0,0,1000,1000&m=g
* omero-ms-image-region/webgateway/render_image_region/<image_id>/0/0/?region=0,0,1000,1000&c=1%7C0:255$FF0000
* omero-ms-image-region/webgateway/render_image_region/<image_id>/0/0/?region=0,0,1000,1000&m=g&c=1%7C0:255$FF0000
```