### PR TITLE
Add projection support

### DIFF
--- a/src/main/java/com/glencoesoftware/omero/ms/image/region/ImageRegionRequestHandler.java
+++ b/src/main/java/com/glencoesoftware/omero/ms/image/region/ImageRegionRequestHandler.java
@@ -43,13 +43,19 @@ import com.sun.media.imageioimpl.plugins.tiff.TIFFImageWriter;
 import com.sun.media.imageioimpl.plugins.tiff.TIFFImageWriterSpi;
 
 import ome.api.local.LocalCompress;
+import ome.io.nio.InMemoryPlanarPixelBuffer;
 import ome.io.nio.PixelBuffer;
 import ome.io.nio.PixelsService;
+import ome.model.core.Image;
+import ome.model.core.Pixels;
+import ome.model.display.ChannelBinding;
 import ome.model.display.RenderingDef;
 import ome.model.enums.Family;
+import ome.model.enums.ProjectionType;
 import ome.model.enums.RenderingModel;
 import ome.util.ImageUtil;
 import omeis.providers.re.Renderer;
+import omeis.providers.re.RenderingStats;
 import omeis.providers.re.codomain.ReverseIntensityContext;
 import omeis.providers.re.data.PlaneDef;
 import omeis.providers.re.data.RegionDef;
@@ -62,9 +68,6 @@ import omero.ServerError;
 import omero.api.IPixelsPrx;
 import omero.api.IQueryPrx;
 import omero.api.ServiceFactoryPrx;
-import omero.model.Image;
-import omero.model.ImageI;
-import omero.model.Pixels;
 import omero.sys.ParametersI;
 import omero.util.IceMapper;
 
@@ -81,6 +84,9 @@ public class ImageRegionRequestHandler {
 
     /** Reference to the compression service. */
     private final LocalCompress compressionSrv;
+
+    /** Reference to the projection service. */
+    private final ProjectionService projectionService;
 
     /** Lookup table provider. */
     private final LutProvider lutProvider;
@@ -119,6 +125,7 @@ public class ImageRegionRequestHandler {
         this.lutProvider = lutProvider;
 
         pixelsService = (PixelsService) context.getBean("/OMERO/Pixels");
+        projectionService = new ProjectionService();
         compressionSrv =
                 (LocalCompress) context.getBean("internal-ome.api.ICompress");
     }
@@ -200,8 +207,7 @@ public class ImageRegionRequestHandler {
             throws ApiUsageException {
         StopWatch t0 = new Slf4JStopWatch("getPixelBuffer");
         try {
-            return pixelsService.getPixelBuffer(
-                    (ome.model.core.Pixels) mapper.reverse(pixels), false);
+            return pixelsService.getPixelBuffer(pixels, false);
         } finally {
             t0.stop();
         }
@@ -230,12 +236,13 @@ public class ImageRegionRequestHandler {
         try {
             long pixelsId =
                     ((omero.RLong) pixelsIdAndSeries.get(0)).getValue();
-            pixels = iPixels.retrievePixDescription(pixelsId, ctx);
+            pixels = (Pixels) mapper.reverse(
+                    iPixels.retrievePixDescription(pixelsId, ctx));
             // The series will be used by our version of PixelsService which
             // avoids attempting to retrieve the series from the database
             // via IQuery later.
-            Image image = new ImageI(pixels.getImage().getId(), true);
-            image.setSeries((omero.RInt) pixelsIdAndSeries.get(1));
+            Image image = new Image(pixels.getImage().getId(), true);
+            image.setSeries(((omero.RInt) pixelsIdAndSeries.get(1)).getValue());
             pixels.setImage(image);
         } finally {
             t0.stop();
@@ -245,8 +252,7 @@ public class ImageRegionRequestHandler {
 
         renderer = new Renderer(
             quantumFactory, renderingModels,
-            (ome.model.core.Pixels) mapper.reverse(pixels),
-            getRenderingDef(iPixels, pixels.getId().getValue()),
+            pixels, getRenderingDef(iPixels, pixels.getId()),
             pixelBuffer, lutProvider
         );
         PlaneDef planeDef = new PlaneDef(PlaneDef.XY, imageRegionCtx.t);
@@ -264,7 +270,7 @@ public class ImageRegionRequestHandler {
         StopWatch t1 = new Slf4JStopWatch("render");
         try {
             // The actual act of rendering will close the provided pixel buffer
-            return render(renderer, resolutionLevels, planeDef);
+            return render(renderer, resolutionLevels, pixels, planeDef);
         } finally {
             t1.stop();
         }
@@ -276,6 +282,7 @@ public class ImageRegionRequestHandler {
      * @param renderer fully initialized renderer
      * @param resolutionLevels complete definition of all resolution levels
      * for the image.
+     * @param pixels pixels metadata
      * @param planeDef plane definition to use for rendering
      * @return Image region as a byte array.
      * @throws ServerError
@@ -284,26 +291,85 @@ public class ImageRegionRequestHandler {
      */
     private byte[] render(
             Renderer renderer, List<List<Integer>> resolutionLevels,
-            PlaneDef planeDef)
+            Pixels pixels, PlaneDef planeDef)
                     throws ServerError, IOException, QuantizationException {
         checkPlaneDef(resolutionLevels, planeDef);
 
         StopWatch t0 = new Slf4JStopWatch("Renderer.renderAsPackedInt");
         int[] buf;
         try {
-            buf =  renderer.renderAsPackedInt(planeDef, null);
+            PixelBuffer newBuffer = null;
+            if (imageRegionCtx.projection != null) {
+                byte[][][][] planes = new byte[1][pixels.getSizeC()][1][];
+                int projectedSizeC = 0;
+                ChannelBinding[] channelBindings =
+                        renderer.getChannelBindings();
+                PixelBuffer pixelBuffer = getPixelBuffer(pixels);
+                int start = Optional
+                        .ofNullable(imageRegionCtx.projectionStart)
+                        .orElse(0);
+                int end = Optional
+                        .ofNullable(imageRegionCtx.projectionEnd)
+                        .orElse(pixels.getSizeZ() - 1);
+                try {
+                    for (int i = 0; i < channelBindings.length; i++) {
+                        if (!channelBindings[i].getActive()) {
+                            continue;
+                        }
+                        StopWatch t1 = new Slf4JStopWatch(
+                                "ProjectionService.projectStack");
+                        try {
+                            planes[0][i][0] = projectionService.projectStack(
+                                pixels,
+                                pixelBuffer,
+                                imageRegionCtx.projection.ordinal(),
+                                imageRegionCtx.t,
+                                i,  // Channel index
+                                1,  // Stepping 1 in ImageWrapper.renderJpeg()
+                                start,
+                                end
+                            );
+                        } finally {
+                            t1.stop();
+                        }
+                        projectedSizeC++;
+                    }
+                } finally {
+                    pixelBuffer.close();
+                }
+                Pixels projectedPixels = new Pixels(
+                    pixels.getImage(),
+                    pixels.getPixelsType(),
+                    pixels.getSizeX(),
+                    pixels.getSizeY(),
+                    1,  // Z
+                    projectedSizeC,
+                    1,  // T
+                    "",
+                    pixels.getDimensionOrder()
+                );
+                newBuffer = new InMemoryPlanarPixelBuffer(
+                        projectedPixels, planes);
+                planeDef = new PlaneDef(PlaneDef.XY, 0);
+                planeDef.setZ(0);
+            }
+            buf =  renderer.renderAsPackedInt(planeDef, newBuffer);
         } finally {
             t0.stop();
             if (log.isDebugEnabled()) {
-                log.debug(renderer.getStats().getStats());
+                RenderingStats stats = renderer.getStats();
+                if (stats != null) {
+                    log.debug(renderer.getStats().getStats());
+                }
             }
         }
 
         String format = imageRegionCtx.format;
+        RegionDef region = planeDef.getRegion();
+        int sizeX = region != null? region.getWidth() : pixels.getSizeX();
+        int sizeY = region != null? region.getHeight() : pixels.getSizeY();
         BufferedImage image = ImageUtil.createBufferedImage(
-            buf,
-            planeDef.getRegion().getWidth(),
-            planeDef.getRegion().getHeight()
+            buf, sizeX, sizeY
         );
         ByteArrayOutputStream output = new ByteArrayOutputStream();
         if (format.equals("jpeg")) {
@@ -443,9 +509,8 @@ public class ImageRegionRequestHandler {
      * @throws IllegalArgumentException
      * @throws ServerError
      */
-    private RegionDef getRegionDef(
-            Pixels pixels, PixelBuffer pixelBuffer)
-                    throws IllegalArgumentException, ServerError {
+    private RegionDef getRegionDef(Pixels pixels, PixelBuffer pixelBuffer)
+            throws IllegalArgumentException, ServerError {
         log.debug("Setting region to read");
         RegionDef regionDef = new RegionDef();
         if (imageRegionCtx.tile != null) {
@@ -462,8 +527,8 @@ public class ImageRegionRequestHandler {
         } else {
             regionDef.setX(0);
             regionDef.setY(0);
-            regionDef.setWidth(pixels.getSizeX().getValue());
-            regionDef.setHeight(pixels.getSizeY().getValue());
+            regionDef.setWidth(pixels.getSizeX());
+            regionDef.setHeight(pixels.getSizeY());
         }
         return regionDef;
     }

--- a/src/main/java/com/glencoesoftware/omero/ms/image/region/ProjectionService.java
+++ b/src/main/java/com/glencoesoftware/omero/ms/image/region/ProjectionService.java
@@ -1,0 +1,317 @@
+/*
+ * Copyright (C) 2018 Glencoe Software, Inc. All rights reserved.
+ *
+ * This program is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation; either version 2 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License along
+ * with this program; if not, write to the Free Software Foundation, Inc.,
+ * 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
+ */
+
+package com.glencoesoftware.omero.ms.image.region;
+
+import java.io.IOException;
+import java.nio.ByteBuffer;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import ome.api.IProjection;
+import ome.conditions.ResourceError;
+import ome.conditions.ValidationException;
+import ome.io.nio.DimensionsOutOfBoundsException;
+import ome.io.nio.PixelBuffer;
+import ome.util.PixelData;
+import ome.model.core.Pixels;
+import ome.model.enums.PixelsType;
+
+/**
+ * Implements projection functionality for Pixels sets as declared in {@link
+ * IProjection}.  Adapted from {@link ome.services.projection.ProjectionBean}.
+ */
+public class ProjectionService {
+
+    /** The logger for this class. */
+    private static Logger log =
+            LoggerFactory.getLogger(ProjectionService.class);
+
+    public byte[] projectStack(Pixels pixels, PixelBuffer pixelBuffer,
+                               int algorithm, int timepoint,
+                               int channelIndex, int stepping,
+                               int start, int end)
+    {
+        ProjectionContext ctx = new ProjectionContext();
+        ctx.pixels = pixels;
+        zIntervalBoundsCheck(start, end, ctx.pixels.getSizeZ());
+        outOfBoundsStepping(stepping);
+        outOfBoundsCheck(channelIndex, "channel");
+        outOfBoundsCheck(timepoint, "timepoint");
+        Integer v = ctx.pixels.getSizeT();
+        if (timepoint >= v) {
+            throw new ValidationException("timepoint must be <" + v);
+        }
+        v = ctx.pixels.getSizeC();
+        if (channelIndex >= v) {
+            throw new ValidationException("channel index must be <" + v);
+        }
+        try {
+            PixelsType pixelsType = pixels.getPixelsType();
+            ctx.planeSizeInPixels =
+                ctx.pixels.getSizeX() * ctx.pixels.getSizeY();
+            int planeSize =
+                ctx.planeSizeInPixels * (pixelsType.getBitSize() / 8);
+            byte[] buf = new byte[planeSize];
+            ctx.from = pixelBuffer.getStack(channelIndex, timepoint);
+            ctx.to = new PixelData(pixelsType.getValue(), ByteBuffer.wrap(buf));
+
+            switch (algorithm) {
+                case IProjection.MAXIMUM_INTENSITY: {
+                    projectStackMax(ctx, stepping, start, end, false);
+                    break;
+                }
+                case IProjection.MEAN_INTENSITY: {
+                    projectStackMean(ctx, stepping, start, end, false);
+                    break;
+                }
+                case IProjection.SUM_INTENSITY: {
+                    projectStackSum(ctx, stepping, start, end, false);
+                    break;
+                }
+                default: {
+                    throw new IllegalArgumentException(
+                            "Unknown algorithm: " + algorithm);
+                }
+            }
+            return buf;
+        }
+        catch (IOException e) {
+            String error = String.format(
+                    "I/O error retrieving stack C=%d T=%d: %s",
+                    channelIndex, timepoint, e.getMessage());
+            log.error(error, e);
+            throw new ResourceError(error);
+        } catch (DimensionsOutOfBoundsException e) {
+            String error = String.format(
+                    "C=%d or T=%d out of range for Pixels Id %d: %s",
+                    channelIndex, timepoint, ctx.pixels.getId(),
+                    e.getMessage());
+            log.error(error, e);
+            throw new ValidationException(error);
+        } finally {
+            try {
+                pixelBuffer.close();
+            } catch (IOException e) {
+                log.error("Buffer did not close successfully.", e);
+                throw new ResourceError(
+                        e.getMessage() + " Please check server log.");
+            }
+            if (ctx.from != null) {
+                ctx.from.dispose();
+            }
+        }
+    }
+
+    /**
+     * Ensures that a particular dimension value is not out of range (ex. less
+     * than zero).
+     * @param value The value to check.
+     * @param name The name of the value to be used for error reporting.
+     * @throws ValidationException If <code>value</code> is out of range.
+     */
+    private void outOfBoundsCheck(Integer value, String name) {
+        if (value != null && value < 0) {
+            throw new ValidationException(name + ": " + value + " < 0");
+        }
+    }
+
+    /**
+     * Ensures that a particular dimension value is not out of range.
+     * @param value The value to check.
+     * @throws ValidationException If <code>value</code> is out of range.
+     */
+    private void outOfBoundsStepping(Integer value) {
+        if (value != null && value <= 0) {
+            throw new ValidationException("stepping: " + value + " <= 0");
+        }
+    }
+
+    /**
+     * Ensures that a particular dimension value is not out of range (ex. less
+     * than zero).
+     * @param start The lower bound of the interval.
+     * @param end The upper bound of the interval.
+     * @param name The name of the value to be used for error reporting.
+     * @throws ValidationException If <code>value</code> is out of range.
+     */
+    private void zIntervalBoundsCheck(int start, int end, Integer maxZ) {
+        if (start < 0 || end < 0)
+            throw new ValidationException(
+                    "Z interval value cannot be negative.");
+        if (start >= maxZ || end >= maxZ)
+            throw new ValidationException(
+                    "Z interval value cannot be >= "+maxZ);
+    }
+
+    /**
+     * Projects a stack based on the maximum intensity at each XY coordinate.
+     * @param ctx The context of our projection.
+     * @param stepping Stepping value to use while calculating the projection.
+     * For example, <code>stepping=1</code> will use every optical section from
+     * <code>start</code> to <code>end</code> where <code>stepping=2</code> will
+     * use every other section from <code>start</code> to <code>end</code> to
+     * perform the projection.
+     * @param start Optical section to start projecting from.
+     * @param end Optical section to finish projecting.
+     * @param doMinMax Whether or not to calculate the minimum and maximum of
+     * the projected pixel data.
+     */
+    private void projectStackMax(ProjectionContext ctx, int stepping,
+                                 int start, int end, boolean doMinMax) {
+        int currentPlaneStart;
+        double projectedValue, stackValue;
+        double minimum = ctx.minimum;
+        double maximum = ctx.maximum;
+        for (int i = 0; i < ctx.planeSizeInPixels; i++) {
+            projectedValue = 0;
+            for (int z = start; z <= end; z += stepping) {
+                currentPlaneStart = ctx.planeSizeInPixels * z;
+                stackValue = ctx.from.getPixelValue(currentPlaneStart + i);
+                if (stackValue > projectedValue) {
+                    projectedValue = stackValue;
+                }
+            }
+            ctx.to.setPixelValue(i, projectedValue);
+            if (doMinMax) {
+                minimum = projectedValue < minimum? projectedValue : minimum;
+                maximum = projectedValue > maximum? projectedValue : maximum;
+            }
+        }
+        ctx.minimum = minimum;
+        ctx.maximum = maximum;
+    }
+
+    /**
+     * Projects a stack based on the mean intensity at each XY coordinate.
+     * @param from The raw pixel data from the stack to project from.
+     * @param ctx The context of our projection.
+     * source Pixels set pixels type will be used.
+     * @param stepping Stepping value to use while calculating the projection.
+     * For example, <code>stepping=1</code> will use every optical section from
+     * <code>start</code> to <code>end</code> where <code>stepping=2</code> will
+     * use every other section from <code>start</code> to <code>end</code> to
+     * perform the projection.
+     * @param start Optical section to start projecting from.
+     * @param end Optical section to finish projecting.
+     * @param doMinMax Whether or not to calculate the minimum and maximum of
+     * the projected pixel data.
+     */
+    private void projectStackMean(ProjectionContext ctx, int stepping,
+                                  int start, int end, boolean doMinMax) {
+        projectStackMeanOrSum(ctx, stepping, start, end, true, doMinMax);
+    }
+
+    /**
+     * Projects a stack based on the sum intensity at each XY coordinate.
+     * @param ctx The context of our projection.
+     * @param pixelsType The destination Pixels type. If <code>null</code>, the
+     * source Pixels set pixels type will be used.
+     * @param stepping Stepping value to use while calculating the projection.
+     * For example, <code>stepping=1</code> will use every optical section from
+     * <code>start</code> to <code>end</code> where <code>stepping=2</code> will
+     * use every other section from <code>start</code> to <code>end</code> to
+     * perform the projection.
+     * @param start Optical section to start projecting from.
+     * @param end Optical section to finish projecting.
+     * @param doMinMax Whether or not to calculate the minimum and maximum of
+     * the projected pixel data.
+     */
+    private void projectStackSum(ProjectionContext ctx, int stepping,
+                                 int start, int end, boolean doMinMax) {
+        projectStackMeanOrSum(ctx, stepping, start, end, false, doMinMax);
+    }
+
+    /**
+     * Projects a stack based on the sum intensity at each XY coordinate with
+     * the option to also average the sum intensity.
+     * @param ctx The context of our projection.
+     * @param pixelsType The destination Pixels type. If <code>null</code>, the
+     * source Pixels set pixels type will be used.
+     * @param stepping Stepping value to use while calculating the projection.
+     * For example, <code>stepping=1</code> will use every optical section from
+     * <code>start</code> to <code>end</code> where <code>stepping=2</code> will
+     * use every other section from <code>start</code> to <code>end</code> to
+     * perform the projection.
+     * @param start Optical section to start projecting from.
+     * @param end Optical section to finish projecting.
+     * @param mean Whether or not we're performing an average post sum
+     * intensity projection.
+     * @param doMinMax Whether or not to calculate the minimum and maximum of
+     * the projected pixel data.
+     */
+    private void projectStackMeanOrSum(ProjectionContext ctx, int stepping,
+                                       int start, int end,
+                                       boolean mean, boolean doMinMax) {
+        double planeMaximum = ctx.to.getMaximum();
+
+        int currentPlaneStart;
+        double projectedValue, stackValue;
+        double minimum = ctx.minimum;
+        double maximum = ctx.maximum;
+        for (int i = 0; i < ctx.planeSizeInPixels; i++) {
+            projectedValue = 0;
+            int projectedPlaneCount = 0;
+            for (int z = start; z < end; z += stepping) {
+                currentPlaneStart = ctx.planeSizeInPixels * z;
+                stackValue = ctx.from.getPixelValue(currentPlaneStart + i);
+                projectedValue += stackValue;
+                projectedPlaneCount++;
+            }
+            if (mean) {
+                projectedValue = projectedValue / projectedPlaneCount;
+            }
+            if (projectedValue > planeMaximum) {
+                projectedValue = planeMaximum;
+            }
+            ctx.to.setPixelValue(i, projectedValue);
+            if (doMinMax) {
+                minimum = projectedValue < minimum? projectedValue : minimum;
+                maximum = projectedValue > maximum? projectedValue : maximum;
+            }
+        }
+        ctx.minimum = minimum;
+        ctx.maximum = maximum;
+    }
+
+    /**
+     * Stores the context of a projection operation.  Adapted from
+     * {@link ome.services.projection.ProjectionBean.ProjectionContext}.
+     */
+    private class ProjectionContext {
+
+        /** The Pixels set we're currently working on. */
+        public Pixels pixels;
+
+        /** Count of the number of pixels per plane for <code>pixels</code>. */
+        public int planeSizeInPixels;
+
+        /** Current minimum for the projected pixel data. */
+        public double minimum = Double.MAX_VALUE;
+
+        /** Current maximum for the projected pixel data. */
+        public double maximum = Double.MIN_VALUE;
+
+        /** The raw pixel data from the stack to project from. */
+        public PixelData from;
+
+        /** The raw pixel data buffer to project into. */
+        public PixelData to;
+    }
+}


### PR DESCRIPTION
Adds support for projections to the microservice. The `ProjectionBean` from the current OMERO `server` component is not ideally suited for re-use outside of a Hibernate session so its implementation has been cribbed out here.

/cc @joshmoore 

--exclude