### PR TITLE
Allow for configurable request parsing limits

### DIFF
--- a/src/dist/conf/config.yaml
+++ b/src/dist/conf/config.yaml
@@ -1,5 +1,13 @@
 # The port that the microservice will listen on
 port: 8080
+# Configuration for request parsing limits
+#  * https://vertx.io/docs/apidocs/io/vertx/core/http/HttpServerOptions.html#setMaxInitialLineLength-int-
+#  * https://vertx.io/docs/apidocs/io/vertx/core/http/HttpServerOptions.html#setMaxHeaderSize-int-
+#  * https://vertx.io/docs/apidocs/io/vertx/core/http/HttpServerOptions.html#setMaxChunkSize-int-
+#  * https://netty.io/4.0/api/io/netty/handler/codec/http/HttpRequestDecoder.html#HttpRequestDecoder--
+# max-initial-line-length: 4096
+# max-header-size: 8192
+# max-chunk-size: 8192
 # OMERO server that the microservice will communicate with (as a client)
 omero:
     host: "localhost"

--- a/src/main/java/com/glencoesoftware/omero/ms/image/region/ImageRegionMicroserviceVerticle.java
+++ b/src/main/java/com/glencoesoftware/omero/ms/image/region/ImageRegionMicroserviceVerticle.java
@@ -36,6 +36,7 @@ import io.vertx.core.Future;
 import io.vertx.core.buffer.Buffer;
 import io.vertx.core.eventbus.ReplyException;
 import io.vertx.core.http.HttpServer;
+import io.vertx.core.http.HttpServerOptions;
 import io.vertx.core.http.HttpServerRequest;
 import io.vertx.core.http.HttpServerResponse;
 import io.vertx.core.json.Json;
@@ -135,7 +136,21 @@ public class ImageRegionMicroserviceVerticle extends AbstractVerticle {
                         .setMultiThreaded(true)
                         .setConfig(config));
 
-        HttpServer server = vertx.createHttpServer();
+        HttpServerOptions options = new HttpServerOptions();
+        options.setMaxInitialLineLength(config.getInteger(
+            "max-initial-line-length",
+            HttpServerOptions.DEFAULT_MAX_INITIAL_LINE_LENGTH)
+        );
+        options.setMaxHeaderSize(config.getInteger(
+            "max-header-size",
+            HttpServerOptions.DEFAULT_MAX_HEADER_SIZE)
+        );
+        options.setMaxChunkSize(config.getInteger(
+            "max-chunk-size",
+            HttpServerOptions.DEFAULT_MAX_CHUNK_SIZE)
+        );
+
+        HttpServer server = vertx.createHttpServer(options);
         Router router = Router.router(vertx);
 
         // Cookie handler so we can pick up the OMERO.web session


### PR DESCRIPTION
During the OMERO 5.3.x and 5.4.x development cycle many elements have been added to various parts of the URI that can result in **very** long URIs for images with large channel counts.

This PR allows the system administrator to configure the limits the microservice is to use for header parsing.

/cc @stick 