### PR TITLE
File descriptor safety

### DIFF
--- a/src/main/java/com/glencoesoftware/omero/ms/image/region/ImageRegionMicroserviceVerticle.java
+++ b/src/main/java/com/glencoesoftware/omero/ms/image/region/ImageRegionMicroserviceVerticle.java
@@ -231,7 +231,9 @@ public class ImageRegionMicroserviceVerticle extends AbstractVerticle {
                     if (t instanceof ReplyException) {
                         statusCode = ((ReplyException) t).failureCode();
                     }
-                    response.setStatusCode(statusCode);
+                    if (!response.closed()) {
+                        response.setStatusCode(statusCode).end();
+                    }
                     return;
                 }
                 byte[] imageRegion = result.result().body();
@@ -249,7 +251,9 @@ public class ImageRegionMicroserviceVerticle extends AbstractVerticle {
                 response.headers().set(
                         "Content-Length",
                         String.valueOf(imageRegion.length));
-                response.write(Buffer.buffer(imageRegion));
+                if (!response.closed()) {
+                    response.end(Buffer.buffer(imageRegion));
+                }
             } finally {
                 response.end();
                 log.debug("Response ended");


### PR DESCRIPTION
Be more sure that we have no chance of a `PixelBuffer` not getting closed. Also, do not attempt to respond to an already closed connection. Should reduce the number of erroneous errors in the log when looking for problems.