### PR TITLE
Support for X and Y axis image mirroring

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -10,3 +10,6 @@ target
 
 .DS_Store
 */.DS_Store
+
+#vim
+*.swp

--- a/build.gradle
+++ b/build.gradle
@@ -81,6 +81,7 @@ dependencies {
         exclude group: 'org.testng', module: 'testng'
     }
     testCompile 'org.testng:testng:6.10'
+    testCompile 'org.mockito:mockito-core:2.+'
 }
 
 jar {

--- a/build.gradle
+++ b/build.gradle
@@ -81,7 +81,6 @@ dependencies {
         exclude group: 'org.testng', module: 'testng'
     }
     testCompile 'org.testng:testng:6.10'
-    testCompile 'org.mockito:mockito-core:2.+'
 }
 
 jar {

--- a/src/main/java/com/glencoesoftware/omero/ms/image/region/ImageRegionCtx.java
+++ b/src/main/java/com/glencoesoftware/omero/ms/image/region/ImageRegionCtx.java
@@ -93,6 +93,12 @@ public class ImageRegionCtx extends OmeroRequestCtx {
     /** Rendering output format */
     public String format;
 
+    /** Whether or not to mirror over the X axis */
+    public boolean mirrorX;
+
+    /** Whether or not to mirror over the Y axis */
+    public boolean mirrorY;
+
     /**
      * Constructor for jackson to decode the object from string
      */
@@ -117,6 +123,10 @@ public class ImageRegionCtx extends OmeroRequestCtx {
         getInvertedAxisFromString(params.get("ia"));
         getProjectionFromString(params.get("p"));
         String maps = params.get("maps");
+        String mirror = Optional.ofNullable(params.get("mirror"))
+                .orElse("").toLowerCase();
+        mirrorX = mirror.contains("x");
+        mirrorY = mirror.contains("y");
         if (maps != null) {
             this.maps = Json.decodeValue(maps, List.class);
         }

--- a/src/main/java/com/glencoesoftware/omero/ms/image/region/ImageRegionCtx.java
+++ b/src/main/java/com/glencoesoftware/omero/ms/image/region/ImageRegionCtx.java
@@ -93,11 +93,11 @@ public class ImageRegionCtx extends OmeroRequestCtx {
     /** Rendering output format */
     public String format;
 
-    /** Whether or not to mirror over the X axis */
-    public boolean mirrorX;
+    /** Whether or not to flip horizontally */
+    public boolean flipHorizontal;
 
-    /** Whether or not to mirror over the Y axis */
-    public boolean mirrorY;
+    /** Whether or not to flip vertically */
+    public boolean flipVertical;
 
     /**
      * Constructor for jackson to decode the object from string
@@ -123,10 +123,10 @@ public class ImageRegionCtx extends OmeroRequestCtx {
         getInvertedAxisFromString(params.get("ia"));
         getProjectionFromString(params.get("p"));
         String maps = params.get("maps");
-        String mirror = Optional.ofNullable(params.get("mirror"))
+        String flip = Optional.ofNullable(params.get("flip"))
                 .orElse("").toLowerCase();
-        mirrorX = mirror.contains("x");
-        mirrorY = mirror.contains("y");
+        flipHorizontal = flip.contains("h");
+        flipVertical = flip.contains("v");
         if (maps != null) {
             this.maps = Json.decodeValue(maps, List.class);
         }

--- a/src/main/java/com/glencoesoftware/omero/ms/image/region/ImageRegionRequestHandler.java
+++ b/src/main/java/com/glencoesoftware/omero/ms/image/region/ImageRegionRequestHandler.java
@@ -562,13 +562,12 @@ public class ImageRegionRequestHandler {
      * @throws IllegalArgumentException
      * @see ImageRegionRequestHandler#getRegionDef(Pixels, PixelBuffer)
      */
-    protected void truncateRegionDef(
-            Pixels pixels, RegionDef regionDef) {
+    protected void truncateRegionDef(Pixels pixels, RegionDef regionDef) {
         log.debug("Truncating RegionDef if required");
-        int sizeX = pixels.getSizeX();
-        int sizeY = pixels.getSizeY();
-        regionDef.setWidth(Math.min(regionDef.getWidth(), sizeX - regionDef.getX()));
-        regionDef.setHeight(Math.min(regionDef.getHeight(), sizeY - regionDef.getY()));
+        regionDef.setWidth(Math.min(
+                regionDef.getWidth(), pixels.getSizeX() - regionDef.getX()));
+        regionDef.setHeight(Math.min(
+                regionDef.getHeight(), pixels.getSizeY() - regionDef.getY()));
     }
 
     /**
@@ -580,8 +579,7 @@ public class ImageRegionRequestHandler {
      * @throws ServerError
      * @see ImageRegionRequestHandler#getRegionDef(Pixels, PixelBuffer)
      */
-    protected void mirrorRegionDef(
-            Pixels pixels, RegionDef regionDef) {
+    protected void mirrorRegionDef(Pixels pixels, RegionDef regionDef) {
         log.debug("Mirroring tile RegionDef if required");
         int sizeX = pixels.getSizeX();
         int sizeY = pixels.getSizeY();

--- a/src/main/java/com/glencoesoftware/omero/ms/image/region/ImageRegionRequestHandler.java
+++ b/src/main/java/com/glencoesoftware/omero/ms/image/region/ImageRegionRequestHandler.java
@@ -52,7 +52,6 @@ import ome.model.core.Pixels;
 import ome.model.display.ChannelBinding;
 import ome.model.display.RenderingDef;
 import ome.model.enums.Family;
-import ome.model.enums.ProjectionType;
 import ome.model.enums.RenderingModel;
 import ome.util.ImageUtil;
 import omeis.providers.re.Renderer;

--- a/src/main/java/com/glencoesoftware/omero/ms/image/region/ImageRegionRequestHandler.java
+++ b/src/main/java/com/glencoesoftware/omero/ms/image/region/ImageRegionRequestHandler.java
@@ -427,7 +427,8 @@ public class ImageRegionRequestHandler {
      * if no flipping has been requested.
      */
     public static int[] flip(
-            int[] src, int sizeX, int sizeY, boolean flipHorizontal, boolean flipVertical) {
+            int[] src, int sizeX, int sizeY,
+            boolean flipHorizontal, boolean flipVertical) {
         if (!flipHorizontal && !flipVertical) {
             return src;
         }

--- a/src/main/java/com/glencoesoftware/omero/ms/image/region/ImageRegionRequestHandler.java
+++ b/src/main/java/com/glencoesoftware/omero/ms/image/region/ImageRegionRequestHandler.java
@@ -29,6 +29,8 @@ import java.util.List;
 import java.util.Map;
 import java.util.Optional;
 
+import java.lang.IllegalArgumentException;
+
 import javax.imageio.IIOImage;
 import javax.imageio.ImageIO;
 import javax.imageio.spi.IIORegistry;
@@ -426,6 +428,12 @@ public class ImageRegionRequestHandler {
             int[] src, int sizeX, int sizeY, boolean mirrorX, boolean mirrorY) {
         if (!mirrorX && !mirrorY) {
             return src;
+        }
+
+        if (src == null) {
+            throw new IllegalArgumentException("Attempted to mirror null image");
+        } else if (sizeX == 0 || sizeY == 0) {
+            throw new IllegalArgumentException("Attempted to mirror image with 0 size");
         }
 
         int[] dest = new int[src.length];

--- a/src/main/java/com/glencoesoftware/omero/ms/image/region/ImageRegionRequestHandler.java
+++ b/src/main/java/com/glencoesoftware/omero/ms/image/region/ImageRegionRequestHandler.java
@@ -380,6 +380,8 @@ public class ImageRegionRequestHandler {
         RegionDef region = planeDef.getRegion();
         int sizeX = region != null? region.getWidth() : pixels.getSizeX();
         int sizeY = region != null? region.getHeight() : pixels.getSizeY();
+        buf = mirror(buf, sizeX, sizeY,
+                imageRegionCtx.mirrorX, imageRegionCtx.mirrorY);
         BufferedImage image = ImageUtil.createBufferedImage(
             buf, sizeX, sizeY
         );
@@ -408,6 +410,37 @@ public class ImageRegionRequestHandler {
         }
         log.error("Unknown format {}", imageRegionCtx.format);
         return null;
+    }
+
+    /**
+     * Mirror an image over the X, Y or both axes.
+     * @param src source image buffer
+     * @param sizeX size of <code>src</code> in X (number of columns)
+     * @param sizeY size of <code>src</code> in Y (number of rows)
+     * @param mirrorX whether or not to mirror the image over the X axis
+     * @param mirrorY whether or not to mirror the image over the Y axis
+     * @return Newly allocated buffer with mirroring applied or <code>src</code>
+     * if no mirroring has been requested.
+     */
+    public static int[] mirror(
+            int[] src, int sizeX, int sizeY, boolean mirrorX, boolean mirrorY) {
+        if (!mirrorX && !mirrorY) {
+            return src;
+        }
+
+        int[] dest = new int[src.length];
+        int srcIndex, destIndex;
+        int xOffset = mirrorX? sizeX : 1;
+        int yOffset = mirrorY? sizeY : 1;
+        for (int x = 0; x < sizeX; x++) {
+            for (int y = 0; y < sizeY; y++) {
+                srcIndex = (y * sizeX) + x;
+                destIndex = Math.abs(((yOffset - y - 1) * sizeX))
+                        + Math.abs((xOffset - x - 1));
+                dest[destIndex] = src[srcIndex];
+            }
+        }
+        return dest;
     }
 
     /**

--- a/src/main/java/com/glencoesoftware/omero/ms/image/region/ImageRegionRequestHandler.java
+++ b/src/main/java/com/glencoesoftware/omero/ms/image/region/ImageRegionRequestHandler.java
@@ -553,8 +553,8 @@ public class ImageRegionRequestHandler {
         }
     }
 
-    public static RegionDef getMirroredRegionDef(int pixelSizeX,
-        int pixelSizeY,
+    public static RegionDef getMirroredRegionDef(int imageSizeX,
+        int imageSizeY,
         int tileSizeX,
         int tileSizeY,
         int x, //Tile X position
@@ -563,27 +563,27 @@ public class ImageRegionRequestHandler {
         boolean mirrorY) {
         log.debug("Getting mirrored tile RegionDef");
         RegionDef regionDef = new RegionDef();
-        int edgeSizeX = pixelSizeX % tileSizeX;
-        int edgeSizeY = pixelSizeY % tileSizeY;
+        int edgeSizeX = imageSizeX % tileSizeX;
+        int edgeSizeY = imageSizeY % tileSizeY;
         //Calculate number of tiles
-        int numTilesX = pixelSizeX/tileSizeX;
+        int numTilesX = imageSizeX/tileSizeX;
         if (edgeSizeX != 0)
             numTilesX += 1;
-        int numTilesY = pixelSizeY/tileSizeY;
+        int numTilesY = imageSizeY/tileSizeY;
         if (edgeSizeY != 0)
             numTilesY += 1;
         if (mirrorX) {
             regionDef.setX(numTilesX - 1 - x);
             //If post-mirror we will have the last tile, it may not be full
             if (x == 0 && edgeSizeX != 0) {
-                regionDef.setWidth(pixelSizeX % tileSizeX);
+                regionDef.setWidth(imageSizeX % tileSizeX);
             } else { //Just a standard size tile
                 regionDef.setWidth(tileSizeX);
             }
         } else{
             regionDef.setX(x);
             //If it's the last tile, it may not be full
-            if (x == pixelSizeX/tileSizeX - 1 && edgeSizeX != 0) {
+            if (x == imageSizeX/tileSizeX - 1 && edgeSizeX != 0) {
                 regionDef.setWidth(edgeSizeX);
             } else {
                 regionDef.setWidth(tileSizeX);
@@ -600,7 +600,7 @@ public class ImageRegionRequestHandler {
         } else {
             regionDef.setY(y);
             //If it's the last tile, it may not be full
-            if (y == pixelSizeY/tileSizeY - 1 && edgeSizeY != 0) {
+            if (y == imageSizeY/tileSizeY - 1 && edgeSizeY != 0) {
                 regionDef.setHeight(edgeSizeY);
             } else {
                 regionDef.setHeight(tileSizeY);
@@ -639,6 +639,15 @@ public class ImageRegionRequestHandler {
             regionDef.setWidth(pixels.getSizeX());
             regionDef.setHeight(pixels.getSizeY());
         }
+        Dimension tileSize = pixelBuffer.getTileSize();
+        regionDef = getMirroredRegionDef(pixels.getSizeX(),
+            pixels.getSizeX(),
+            (int) tileSize.getWidth(),
+            (int) tileSize.getHeight(),
+            regionDef.getX() / regionDef.getWidth(), //Tile X position
+            regionDef.getY() / regionDef.getHeight(), //Tile Y position
+            imageRegionCtx.mirrorX,
+            imageRegionCtx.mirrorY);
         return regionDef;
     }
 

--- a/src/main/java/com/glencoesoftware/omero/ms/image/region/ImageRegionRequestHandler.java
+++ b/src/main/java/com/glencoesoftware/omero/ms/image/region/ImageRegionRequestHandler.java
@@ -553,6 +553,62 @@ public class ImageRegionRequestHandler {
         }
     }
 
+    public static RegionDef getMirroredRegionDef(int pixelSizeX,
+        int pixelSizeY,
+        int tileSizeX,
+        int tileSizeY,
+        int x, //Tile X position
+        int y, //Tile Y position
+        boolean mirrorX,
+        boolean mirrorY) {
+        log.debug("Getting mirrored tile RegionDef");
+        RegionDef regionDef = new RegionDef();
+        int edgeSizeX = pixelSizeX % tileSizeX;
+        int edgeSizeY = pixelSizeY % tileSizeY;
+        //Calculate number of tiles
+        int numTilesX = pixelSizeX/tileSizeX;
+        if (edgeSizeX != 0)
+            numTilesX += 1;
+        int numTilesY = pixelSizeY/tileSizeY;
+        if (edgeSizeY != 0)
+            numTilesY += 1;
+        if (mirrorX) {
+            regionDef.setX(numTilesX - 1 - x);
+            //If post-mirror we will have the last tile, it may not be full
+            if (x == 0 && edgeSizeX != 0) {
+                regionDef.setWidth(pixelSizeX % tileSizeX);
+            } else { //Just a standard size tile
+                regionDef.setWidth(tileSizeX);
+            }
+        } else{
+            regionDef.setX(x);
+            //If it's the last tile, it may not be full
+            if (x == pixelSizeX/tileSizeX - 1 && edgeSizeX != 0) {
+                regionDef.setWidth(edgeSizeX);
+            } else {
+                regionDef.setWidth(tileSizeX);
+            }
+        }
+        if (mirrorY) {
+            regionDef.setY(numTilesY - 1 - y);
+            //If post-mirror we will have the last tile, it may not be full
+            if (y == 0 && edgeSizeY != 0) {
+                regionDef.setHeight(edgeSizeY);
+            } else { //Just a standard size tile
+                regionDef.setHeight(tileSizeY);
+            }
+        } else {
+            regionDef.setY(y);
+            //If it's the last tile, it may not be full
+            if (y == pixelSizeY/tileSizeY - 1 && edgeSizeY != 0) {
+                regionDef.setHeight(edgeSizeY);
+            } else {
+                regionDef.setHeight(tileSizeY);
+            }
+        }
+        return regionDef;
+    }
+
     /**
      * Returns RegionDef to read based on tile / region provided in
      * ImageRegionCtx.

--- a/src/main/java/com/glencoesoftware/omero/ms/image/region/ImageRegionRequestHandler.java
+++ b/src/main/java/com/glencoesoftware/omero/ms/image/region/ImageRegionRequestHandler.java
@@ -384,8 +384,8 @@ public class ImageRegionRequestHandler {
         RegionDef region = planeDef.getRegion();
         int sizeX = region != null? region.getWidth() : pixels.getSizeX();
         int sizeY = region != null? region.getHeight() : pixels.getSizeY();
-        buf = mirror(buf, sizeX, sizeY,
-                imageRegionCtx.mirrorX, imageRegionCtx.mirrorY);
+        buf = flip(buf, sizeX, sizeY,
+                imageRegionCtx.flipHorizontal, imageRegionCtx.flipVertical);
         BufferedImage image = ImageUtil.createBufferedImage(
             buf, sizeX, sizeY
         );
@@ -417,31 +417,31 @@ public class ImageRegionRequestHandler {
     }
 
     /**
-     * Mirror an image over the X, Y or both axes.
+     * Flip an image horizontally, vertically, or both.
      * @param src source image buffer
      * @param sizeX size of <code>src</code> in X (number of columns)
      * @param sizeY size of <code>src</code> in Y (number of rows)
-     * @param mirrorX whether or not to mirror the image over the X axis
-     * @param mirrorY whether or not to mirror the image over the Y axis
-     * @return Newly allocated buffer with mirroring applied or <code>src</code>
-     * if no mirroring has been requested.
+     * @param flipHorizontal whether or not to flip the image horizontally
+     * @param flipVertical whether or not to flip the image vertically
+     * @return Newly allocated buffer with flipping applied or <code>src</code>
+     * if no flipping has been requested.
      */
-    public static int[] mirror(
-            int[] src, int sizeX, int sizeY, boolean mirrorX, boolean mirrorY) {
-        if (!mirrorX && !mirrorY) {
+    public static int[] flip(
+            int[] src, int sizeX, int sizeY, boolean flipHorizontal, boolean flipVertical) {
+        if (!flipHorizontal && !flipVertical) {
             return src;
         }
 
         if (src == null) {
-            throw new IllegalArgumentException("Attempted to mirror null image");
+            throw new IllegalArgumentException("Attempted to flip null image");
         } else if (sizeX == 0 || sizeY == 0) {
-            throw new IllegalArgumentException("Attempted to mirror image with 0 size");
+            throw new IllegalArgumentException("Attempted to flip image with 0 size");
         }
 
         int[] dest = new int[src.length];
         int srcIndex, destIndex;
-        int xOffset = mirrorX? sizeX : 1;
-        int yOffset = mirrorY? sizeY : 1;
+        int xOffset = flipHorizontal? sizeX : 1;
+        int yOffset = flipVertical? sizeY : 1;
         for (int x = 0; x < sizeX; x++) {
             for (int y = 0; y < sizeY; y++) {
                 srcIndex = (y * sizeX) + x;
@@ -571,23 +571,23 @@ public class ImageRegionRequestHandler {
     }
 
     /**
-     * Update RegionDef to be mirrored if required.
+     * Update RegionDef to be flipped if required.
      * @param pixels pixels metadata
      * @param tileSize XY tile sizes of the underlying pixels
-     * @param regionDef region definition to mirror if required
+     * @param regionDef region definition to flip if required
      * @throws IllegalArgumentException
      * @throws ServerError
      * @see ImageRegionRequestHandler#getRegionDef(Pixels, PixelBuffer)
      */
-    protected void mirrorRegionDef(Pixels pixels, RegionDef regionDef) {
-        log.debug("Mirroring tile RegionDef if required");
+    protected void flipRegionDef(Pixels pixels, RegionDef regionDef) {
+        log.debug("Flipping tile RegionDef if required");
         int sizeX = pixels.getSizeX();
         int sizeY = pixels.getSizeY();
-        if (imageRegionCtx.mirrorX) {
+        if (imageRegionCtx.flipHorizontal) {
             regionDef.setX(
                     sizeX - regionDef.getWidth() - regionDef.getX());
         }
-        if (imageRegionCtx.mirrorY) {
+        if (imageRegionCtx.flipVertical) {
             regionDef.setY(
                     sizeY - regionDef.getHeight() - regionDef.getY());
         }
@@ -625,7 +625,7 @@ public class ImageRegionRequestHandler {
             return regionDef;
         }
         truncateRegionDef(pixels, regionDef);
-        mirrorRegionDef(pixels, regionDef);
+        flipRegionDef(pixels, regionDef);
         return regionDef;
     }
 

--- a/src/main/java/com/glencoesoftware/omero/ms/image/region/ImageRegionVerticle.java
+++ b/src/main/java/com/glencoesoftware/omero/ms/image/region/ImageRegionVerticle.java
@@ -40,6 +40,8 @@ import ome.model.enums.Family;
 import ome.model.enums.RenderingModel;
 import ome.services.scripts.ScriptFileType;
 import ome.system.PreferenceContext;
+import ome.api.local.LocalCompress;
+import ome.io.nio.PixelsService;
 import omeis.providers.re.lut.LutProvider;
 import omero.ApiUsageException;
 import omero.ServerError;
@@ -153,10 +155,15 @@ public class ImageRegionVerticle extends AbstractVerticle {
                 request.execute(this::updateRenderingModels);
             }
 
+            PixelsService pixelsService = (PixelsService) context.getBean("/OMERO/Pixels");
+            LocalCompress compressionService =
+                (LocalCompress) context.getBean("internal-ome.api.ICompress");
             byte[] imageRegion = request.execute(
                     new ImageRegionRequestHandler(
                             imageRegionCtx, context, families,
-                            renderingModels, lutProvider)::renderImageRegion);
+                            renderingModels, lutProvider,
+                            pixelsService,
+                            compressionService)::renderImageRegion);
             if (imageRegion == null) {
                 message.fail(
                         404, "Cannot find Image:" + imageRegionCtx.imageId);

--- a/src/test/java/com/glencoesoftware/omero/ms/image/region/ImageRegionRequestHandlerTest.java
+++ b/src/test/java/com/glencoesoftware/omero/ms/image/region/ImageRegionRequestHandlerTest.java
@@ -20,8 +20,6 @@ package com.glencoesoftware.omero.ms.image.region;
 
 import static org.mockito.Mockito.*;
 
-import java.io.IOException;
-import java.util.Map;
 import java.util.ArrayList;
 import java.lang.Integer;
 import java.awt.Dimension;

--- a/src/test/java/com/glencoesoftware/omero/ms/image/region/ImageRegionRequestHandlerTest.java
+++ b/src/test/java/com/glencoesoftware/omero/ms/image/region/ImageRegionRequestHandlerTest.java
@@ -151,4 +151,21 @@ public class ImageRegionRequestHandlerTest {
         }
         testAllMirrors(src, sizeX, sizeY);
     }
+
+    @Test (expectedExceptions = IllegalArgumentException.class)
+    public void testMirrorNullImage() {
+        ImageRegionRequestHandler.mirror(null, 4, 4, true, true);
+    }
+
+    @Test (expectedExceptions = IllegalArgumentException.class)
+    public void testMirrorZeroXImage() {
+        int[] src = {1};
+        ImageRegionRequestHandler.mirror(src, 0, 4, true, true);
+    }
+
+    @Test (expectedExceptions = IllegalArgumentException.class)
+    public void testMirrorZeroYImage() {
+        int[] src = {1};
+        ImageRegionRequestHandler.mirror(src, 4, 0, true, true);
+    }
 }

--- a/src/test/java/com/glencoesoftware/omero/ms/image/region/ImageRegionRequestHandlerTest.java
+++ b/src/test/java/com/glencoesoftware/omero/ms/image/region/ImageRegionRequestHandlerTest.java
@@ -67,21 +67,19 @@ public class ImageRegionRequestHandlerTest {
             int[] src, int sizeX, int sizeY, boolean mirrorX, boolean mirrorY) {
         int[] mirrored = ImageRegionRequestHandler.mirror(
                 src, sizeX, sizeY, mirrorX, mirrorY);
-        for (int n = 0; n < sizeX*sizeY; n++){
+        for (int n = 0; n < sizeX * sizeY; n++){
             int new_col;
             if (mirrorX) {
                 int old_col = n % sizeX;
                 new_col = sizeX - 1 - old_col;
-            }
-            else {
+            } else {
                 new_col = n % sizeX;
             }
             int new_row;
             if (mirrorY) {
                 int old_row = n / sizeX;
                 new_row = sizeY - 1 - old_row;
-            }
-            else {
+            } else {
                 new_row = n / sizeX;
             }
             Assert.assertEquals(mirrored[new_row * sizeX + new_col], n);
@@ -198,7 +196,7 @@ public class ImageRegionRequestHandlerTest {
 
     @Test
     public void testGetRegionDefCtxTile()
-    throws IllegalArgumentException, ServerError {
+            throws IllegalArgumentException, ServerError {
         int x = 2;
         int y = 2;
         imageRegionCtx.tile = new RegionDef(x, y, 0, 0);
@@ -207,17 +205,18 @@ public class ImageRegionRequestHandlerTest {
         pixels.setSizeY(1024);
         PixelBuffer pixelBuffer = mock(PixelBuffer.class);
         int tileSize = 256;
-        when(pixelBuffer.getTileSize()).thenReturn(new Dimension(tileSize, tileSize));
+        when(pixelBuffer.getTileSize())
+            .thenReturn(new Dimension(tileSize, tileSize));
         RegionDef rdef = reqHandler.getRegionDef(pixels, pixelBuffer);
-        Assert.assertEquals(rdef.getX(), x*tileSize);
-        Assert.assertEquals(rdef.getX(), y*tileSize);
+        Assert.assertEquals(rdef.getX(), x * tileSize);
+        Assert.assertEquals(rdef.getX(), y * tileSize);
         Assert.assertEquals(rdef.getWidth(), tileSize);
         Assert.assertEquals(rdef.getHeight(), tileSize);
     }
 
     @Test
     public void testGetRegionDefCtxRegion()
-    throws IllegalArgumentException, ServerError {
+            throws IllegalArgumentException, ServerError {
         imageRegionCtx.tile = null;
         imageRegionCtx.region = new RegionDef(512, 512, 256, 256);
         Pixels pixels = new Pixels();
@@ -227,8 +226,10 @@ public class ImageRegionRequestHandlerTest {
         RegionDef rdef = reqHandler.getRegionDef(pixels, pixelBuffer);
         Assert.assertEquals(rdef.getX(), imageRegionCtx.region.getX());
         Assert.assertEquals(rdef.getX(), imageRegionCtx.region.getY());
-        Assert.assertEquals(rdef.getWidth(), imageRegionCtx.region.getWidth());
-        Assert.assertEquals(rdef.getHeight(), imageRegionCtx.region.getHeight());
+        Assert.assertEquals(
+                rdef.getWidth(), imageRegionCtx.region.getWidth());
+        Assert.assertEquals(
+                rdef.getHeight(), imageRegionCtx.region.getHeight());
     }
 
     @Test
@@ -253,7 +254,7 @@ public class ImageRegionRequestHandlerTest {
         pixels.setSizeX(1024);
         pixels.setSizeY(1024);
         PixelBuffer pixelBuffer = mock(PixelBuffer.class);
-        when(pixelBuffer.getTileSize()).thenReturn(new Dimension(256,256));
+        when(pixelBuffer.getTileSize()).thenReturn(new Dimension(256, 256));
         imageRegionCtx.region = new RegionDef(100, 200, 300, 400);
         imageRegionCtx.mirrorX = true;
         imageRegionCtx.mirrorY = false;
@@ -270,7 +271,7 @@ public class ImageRegionRequestHandlerTest {
         pixels.setSizeX(1024);
         pixels.setSizeY(1024);
         PixelBuffer pixelBuffer = mock(PixelBuffer.class);
-        when(pixelBuffer.getTileSize()).thenReturn(new Dimension(256,256));
+        when(pixelBuffer.getTileSize()).thenReturn(new Dimension(256, 256));
         imageRegionCtx.region = new RegionDef(100, 200, 300, 400);
         imageRegionCtx.mirrorX = false;
         imageRegionCtx.mirrorY = true;
@@ -287,7 +288,7 @@ public class ImageRegionRequestHandlerTest {
         pixels.setSizeX(1024);
         pixels.setSizeY(1024);
         PixelBuffer pixelBuffer = mock(PixelBuffer.class);
-        when(pixelBuffer.getTileSize()).thenReturn(new Dimension(256,256));
+        when(pixelBuffer.getTileSize()).thenReturn(new Dimension(256, 256));
         imageRegionCtx.region = new RegionDef(100, 200, 300, 400);
         imageRegionCtx.mirrorX = true;
         imageRegionCtx.mirrorY = true;
@@ -306,7 +307,7 @@ public class ImageRegionRequestHandlerTest {
         pixels.setSizeX(768);
         pixels.setSizeY(768);
         PixelBuffer pixelBuffer = mock(PixelBuffer.class);
-        when(pixelBuffer.getTileSize()).thenReturn(new Dimension(512,512));
+        when(pixelBuffer.getTileSize()).thenReturn(new Dimension(512, 512));
         imageRegionCtx.mirrorX = true;
         imageRegionCtx.mirrorY = false;
         RegionDef regionDef = reqHandler.getRegionDef(pixels, pixelBuffer);
@@ -348,7 +349,7 @@ public class ImageRegionRequestHandlerTest {
         pixels.setSizeX(768);
         pixels.setSizeY(768);
         PixelBuffer pixelBuffer = mock(PixelBuffer.class);
-        when(pixelBuffer.getTileSize()).thenReturn(new Dimension(512,512));
+        when(pixelBuffer.getTileSize()).thenReturn(new Dimension(512, 512));
         imageRegionCtx.mirrorY = true;
         RegionDef regionDef = reqHandler.getRegionDef(pixels, pixelBuffer);
         Assert.assertEquals(regionDef.getX(), 0);
@@ -389,7 +390,7 @@ public class ImageRegionRequestHandlerTest {
         pixels.setSizeX(768);
         pixels.setSizeY(768);
         PixelBuffer pixelBuffer = mock(PixelBuffer.class);
-        when(pixelBuffer.getTileSize()).thenReturn(new Dimension(512,512));
+        when(pixelBuffer.getTileSize()).thenReturn(new Dimension(512, 512));
         imageRegionCtx.mirrorX = true;
         imageRegionCtx.mirrorY = true;
         RegionDef regionDef = reqHandler.getRegionDef(pixels, pixelBuffer);

--- a/src/test/java/com/glencoesoftware/omero/ms/image/region/ImageRegionRequestHandlerTest.java
+++ b/src/test/java/com/glencoesoftware/omero/ms/image/region/ImageRegionRequestHandlerTest.java
@@ -18,8 +18,6 @@
 
 package com.glencoesoftware.omero.ms.image.region;
 
-import static org.mockito.Mockito.*;
-
 import java.awt.Dimension;
 import java.util.ArrayList;
 
@@ -29,8 +27,6 @@ import org.testng.annotations.Test;
 
 import io.vertx.core.MultiMap;
 import io.vertx.core.http.CaseInsensitiveHeaders;
-import omero.ServerError;
-import ome.io.nio.PixelBuffer;
 import ome.model.core.Pixels;
 import ome.model.enums.Family;
 import ome.model.enums.RenderingModel;
@@ -197,181 +193,182 @@ public class ImageRegionRequestHandlerTest {
     }
 
     @Test
-    public void testGetMirroredRegionDef() {
-        RegionDef originalRegion = new RegionDef(1, 1, 256, 256);
-        RegionDef finalDef = reqHandler.getMirroredRegionDef(
-            1024,
-            1024,
-            originalRegion.getWidth(),
-            originalRegion.getHeight(),
-            originalRegion.getX(),
-            originalRegion.getY(),
-            false,
-            false);
-        Assert.assertEquals(256, finalDef.getX());
-        Assert.assertEquals(256, finalDef.getY());
-        Assert.assertEquals(256, finalDef.getWidth());
-        Assert.assertEquals(256, finalDef.getHeight());
-    }
-
-    @Test
-    public void testGetMirroredRegionDefX() {
-        RegionDef originalRegion = new RegionDef(1, 1, 256, 256);
-        RegionDef finalDef = reqHandler.getMirroredRegionDef(
-            1024,
-            1024,
-            originalRegion.getWidth(),
-            originalRegion.getHeight(),
-            originalRegion.getX(),
-            originalRegion.getY(),
-            true,
-            false);
-        Assert.assertEquals(512, finalDef.getX());
-        Assert.assertEquals(256, finalDef.getY());
-        Assert.assertEquals(256, finalDef.getWidth());
-        Assert.assertEquals(256, finalDef.getHeight());
-    }
-
-    @Test
-    public void testGetMirroredRegionDefY() {
-        RegionDef originalRegion = new RegionDef(1, 1, 256, 256);
-        RegionDef finalDef = reqHandler.getMirroredRegionDef(
-            1024,
-            1024,
-            originalRegion.getWidth(),
-            originalRegion.getHeight(),
-            originalRegion.getX(),
-            originalRegion.getY(),
-            false,
-            true);
-        Assert.assertEquals(finalDef.getX(), 256);
-        Assert.assertEquals(finalDef.getY(), 512);
-        Assert.assertEquals(finalDef.getWidth(), 256);
-        Assert.assertEquals(finalDef.getHeight(), 256);
-    }
-
-    @Test
-    public void testGetMirroredRegionDefXY() {
-        RegionDef originalRegion = new RegionDef(1, 1, 256, 256);
-        RegionDef finalDef = reqHandler.getMirroredRegionDef(
-            1024,
-            1024,
-            originalRegion.getWidth(),
-            originalRegion.getHeight(),
-            originalRegion.getX(),
-            originalRegion.getY(),
-            true,
-            true);
-        Assert.assertEquals(finalDef.getX(), 512);
-        Assert.assertEquals(finalDef.getY(), 512);
-        Assert.assertEquals(finalDef.getWidth(), 256);
-        Assert.assertEquals(finalDef.getHeight(), 256);
-    }
-
-    @Test
-    public void testGetMirroredRegionDefXEdge() {
-        RegionDef originalRegion = new RegionDef(0, 1, 256, 256);
-        RegionDef finalDef = reqHandler.getMirroredRegionDef(
-            1023,
-            1024,
-            originalRegion.getWidth(),
-            originalRegion.getHeight(),
-            originalRegion.getX(),
-            originalRegion.getY(),
-            true,
-            false);
-        Assert.assertEquals(finalDef.getX(), 768);
-        Assert.assertEquals(finalDef.getY(), 256);
-        Assert.assertEquals(finalDef.getWidth(), 255);
-        Assert.assertEquals(finalDef.getHeight(), 256);
-    }
-
-    @Test
-    public void testGetMirroredRegionDefYEdge() {
-        RegionDef originalRegion = new RegionDef(1, 0, 256, 256);
-        RegionDef finalDef = reqHandler.getMirroredRegionDef(
-            1024,
-            1023,
-            originalRegion.getWidth(),
-            originalRegion.getHeight(),
-            originalRegion.getX(),
-            originalRegion.getY(),
-            false,
-            true);
-        Assert.assertEquals(finalDef.getX(), 256);
-        Assert.assertEquals(finalDef.getY(), 768);
-        Assert.assertEquals(finalDef.getWidth(), 256);
-        Assert.assertEquals(finalDef.getHeight(), 255);
-    }
-
-    @Test
-    public void testGetMirroredRegionDefXYEdge() {
-        RegionDef originalRegion = new RegionDef(0, 0, 256, 256);
-        RegionDef finalDef = reqHandler.getMirroredRegionDef(
-            1023,
-            1023,
-            originalRegion.getWidth(),
-            originalRegion.getHeight(),
-            originalRegion.getX(),
-            originalRegion.getY(),
-            true,
-            true);
-        Assert.assertEquals(finalDef.getX(), 768);
-        Assert.assertEquals(finalDef.getY(), 768);
-        Assert.assertEquals(finalDef.getWidth(), 255);
-        Assert.assertEquals(finalDef.getHeight(), 255);
-    }
-
-    @Test
-    public void testGetRegionDefCtxTile()
-            throws IllegalArgumentException, ServerError {
-        int x = 2;
-        int y = 2;
-        imageRegionCtx.tile = new RegionDef(x, y, 0, 0);
+    public void testMirrorRegionDefMirrorNothing() {
+        RegionDef regionDef = new RegionDef(0, 0, 256, 256);
         Pixels pixels = new Pixels();
         pixels.setSizeX(1024);
         pixels.setSizeY(1024);
-        PixelBuffer pixelBuffer = mock(PixelBuffer.class);
-        int tileSize = 256;
-        when(pixelBuffer.getTileSize())
-            .thenReturn(new Dimension(tileSize, tileSize));
-        RegionDef rdef = reqHandler.getRegionDef(pixels, pixelBuffer);
-        Assert.assertEquals(rdef.getX(), x * tileSize);
-        Assert.assertEquals(rdef.getY(), y * tileSize);
-        Assert.assertEquals(rdef.getWidth(), tileSize);
-        Assert.assertEquals(rdef.getHeight(), tileSize);
+        reqHandler.mirrorRegionDef(pixels, new Dimension(256, 256), regionDef);
+        Assert.assertEquals(regionDef.getX(), 0);
+        Assert.assertEquals(regionDef.getY(), 0);
+        Assert.assertEquals(regionDef.getWidth(), 256);
+        Assert.assertEquals(regionDef.getHeight(), 256);
     }
 
+
     @Test
-    public void testGetRegionDefCtxRegion()
-            throws IllegalArgumentException, ServerError {
-        imageRegionCtx.region = new RegionDef(512, 512, 256, 256);
+    public void testMirrorRegionDefMirrorX() {
+        RegionDef regionDef = new RegionDef(0, 0, 256, 256);
         Pixels pixels = new Pixels();
         pixels.setSizeX(1024);
         pixels.setSizeY(1024);
-        PixelBuffer pixelBuffer = mock(PixelBuffer.class);
-        when(pixelBuffer.getTileSize()).thenReturn(new Dimension(256, 256));
-        RegionDef rdef = reqHandler.getRegionDef(pixels, pixelBuffer);
-        Assert.assertEquals(rdef.getX(), imageRegionCtx.region.getX());
-        Assert.assertEquals(rdef.getY(), imageRegionCtx.region.getY());
-        Assert.assertEquals(rdef.getWidth(), imageRegionCtx.region.getWidth());
-        Assert.assertEquals(
-                rdef.getHeight(), imageRegionCtx.region.getHeight());
+        imageRegionCtx.mirrorX = true;
+        reqHandler.mirrorRegionDef(pixels, new Dimension(256, 256), regionDef);
+        Assert.assertEquals(regionDef.getX(), 768);
+        Assert.assertEquals(regionDef.getY(), 0);
+        Assert.assertEquals(regionDef.getWidth(), 256);
+        Assert.assertEquals(regionDef.getHeight(), 256);
     }
 
     @Test
-    public void testGetRegionDefCtxNoTileOrRegion()
-            throws IllegalArgumentException, ServerError {
+    public void testMirrorRegionDefMirrorY() {
+        RegionDef regionDef = new RegionDef(0, 0, 256, 256);
         Pixels pixels = new Pixels();
         pixels.setSizeX(1024);
         pixels.setSizeY(1024);
-        PixelBuffer pixelBuffer = mock(PixelBuffer.class);
-        when(pixelBuffer.getTileSize()).thenReturn(new Dimension(256, 256));
-        RegionDef rdef = reqHandler.getRegionDef(pixels, pixelBuffer);
-        Assert.assertEquals(rdef.getX(), 0);
-        Assert.assertEquals(rdef.getY(), 0);
-        Assert.assertEquals(rdef.getWidth(), 1024);
-        Assert.assertEquals(rdef.getHeight(), 1024);
+        imageRegionCtx.mirrorY = true;
+        reqHandler.mirrorRegionDef(pixels, new Dimension(256, 256), regionDef);
+        Assert.assertEquals(regionDef.getX(), 0);
+        Assert.assertEquals(regionDef.getY(), 768);
+        Assert.assertEquals(regionDef.getWidth(), 256);
+        Assert.assertEquals(regionDef.getHeight(), 256);
+    }
+
+    @Test
+    public void testMirrorRegionDefMirrorXY() {
+        RegionDef regionDef = new RegionDef(0, 0, 256, 256);
+        Pixels pixels = new Pixels();
+        pixels.setSizeX(1024);
+        pixels.setSizeY(1024);
+        imageRegionCtx.mirrorX = true;
+        imageRegionCtx.mirrorY = true;
+        reqHandler.mirrorRegionDef(pixels, new Dimension(256, 256), regionDef);
+        Assert.assertEquals(regionDef.getX(), 768);
+        Assert.assertEquals(regionDef.getY(), 768);
+        Assert.assertEquals(regionDef.getWidth(), 256);
+        Assert.assertEquals(regionDef.getHeight(), 256);
+    }
+
+    @Test
+    public void testMirrorRegionDefMirorXEdge() {
+        // Tile 0, 0
+        RegionDef regionDef = new RegionDef(0, 0, 512, 512);
+        Pixels pixels = new Pixels();
+        pixels.setSizeX(768);
+        pixels.setSizeY(768);
+        imageRegionCtx.mirrorX = true;
+        reqHandler.mirrorRegionDef(pixels, new Dimension(512, 512), regionDef);
+        Assert.assertEquals(regionDef.getX(), 256);
+        Assert.assertEquals(regionDef.getY(), 0);
+        Assert.assertEquals(regionDef.getWidth(), 512);
+        Assert.assertEquals(regionDef.getHeight(), 512);
+
+        // Tile 1, 0
+        regionDef = new RegionDef(512, 0, 512, 512);
+        reqHandler.mirrorRegionDef(pixels, new Dimension(512, 512), regionDef);
+        Assert.assertEquals(regionDef.getX(), 0);
+        Assert.assertEquals(regionDef.getY(), 0);
+        Assert.assertEquals(regionDef.getWidth(), 256);
+        Assert.assertEquals(regionDef.getHeight(), 512);
+
+        // Tile 0, 1
+        regionDef = new RegionDef(0, 512, 512, 512);
+        reqHandler.mirrorRegionDef(pixels, new Dimension(512, 512), regionDef);
+        Assert.assertEquals(regionDef.getX(), 256);
+        Assert.assertEquals(regionDef.getY(), 512);
+        Assert.assertEquals(regionDef.getWidth(), 512);
+        Assert.assertEquals(regionDef.getHeight(), 512);
+        // ^^ Will be confined to the image sizeY by the rendering operation
+
+        // Tile 1, 1
+        regionDef = new RegionDef(512, 512, 512, 512);
+        reqHandler.mirrorRegionDef(pixels, new Dimension(512, 512), regionDef);
+        Assert.assertEquals(regionDef.getX(), 0);
+        Assert.assertEquals(regionDef.getY(), 512);
+        Assert.assertEquals(regionDef.getWidth(), 256);
+        Assert.assertEquals(regionDef.getHeight(), 512);
+        // ^^ Will be confined to the image sizeY by the rendering operation
+    }
+
+    @Test
+    public void testMirrorRegionDefMirorYEdge() {
+        // Tile 0, 0
+        RegionDef regionDef = new RegionDef(0, 0, 512, 512);
+        Pixels pixels = new Pixels();
+        pixels.setSizeX(768);
+        pixels.setSizeY(768);
+        imageRegionCtx.mirrorY = true;
+        reqHandler.mirrorRegionDef(pixels, new Dimension(512, 512), regionDef);
+        Assert.assertEquals(regionDef.getX(), 0);
+        Assert.assertEquals(regionDef.getY(), 256);
+        Assert.assertEquals(regionDef.getWidth(), 512);
+        Assert.assertEquals(regionDef.getHeight(), 512);
+
+        // Tile 1, 0
+        regionDef = new RegionDef(512, 0, 512, 512);
+        reqHandler.mirrorRegionDef(pixels, new Dimension(512, 512), regionDef);
+        Assert.assertEquals(regionDef.getX(), 512);
+        Assert.assertEquals(regionDef.getY(), 256);
+        Assert.assertEquals(regionDef.getWidth(), 512);
+        // ^^ Will be confined to the image sizeX by the rendering operation
+        Assert.assertEquals(regionDef.getHeight(), 512);
+
+        // Tile 0, 1
+        regionDef = new RegionDef(0, 512, 512, 512);
+        reqHandler.mirrorRegionDef(pixels, new Dimension(512, 512), regionDef);
+        Assert.assertEquals(regionDef.getX(), 0);
+        Assert.assertEquals(regionDef.getY(), 0);
+        Assert.assertEquals(regionDef.getWidth(), 512);
+        Assert.assertEquals(regionDef.getHeight(), 256);
+
+        // Tile 1, 1
+        regionDef = new RegionDef(512, 512, 512, 512);
+        reqHandler.mirrorRegionDef(pixels, new Dimension(512, 512), regionDef);
+        Assert.assertEquals(regionDef.getX(), 512);
+        Assert.assertEquals(regionDef.getY(), 0);
+        Assert.assertEquals(regionDef.getWidth(), 512);
+        // ^^ Will be confined to the image sizeX by the rendering operation
+        Assert.assertEquals(regionDef.getHeight(), 256);
+    }
+
+    @Test
+    public void testMirrorRegionDefMirorXYEdge() {
+        // Tile 0, 0
+        RegionDef regionDef = new RegionDef(0, 0, 512, 512);
+        Pixels pixels = new Pixels();
+        pixels.setSizeX(768);
+        pixels.setSizeY(768);
+        imageRegionCtx.mirrorX = true;
+        imageRegionCtx.mirrorY = true;
+        reqHandler.mirrorRegionDef(pixels, new Dimension(512, 512), regionDef);
+        Assert.assertEquals(regionDef.getX(), 256);
+        Assert.assertEquals(regionDef.getY(), 256);
+        Assert.assertEquals(regionDef.getWidth(), 512);
+        Assert.assertEquals(regionDef.getHeight(), 512);
+
+        // Tile 1, 0
+        regionDef = new RegionDef(512, 0, 512, 512);
+        reqHandler.mirrorRegionDef(pixels, new Dimension(512, 512), regionDef);
+        Assert.assertEquals(regionDef.getX(), 0);
+        Assert.assertEquals(regionDef.getY(), 256);
+        Assert.assertEquals(regionDef.getWidth(), 256);
+        Assert.assertEquals(regionDef.getHeight(), 512);
+
+        // Tile 0, 1
+        regionDef = new RegionDef(0, 512, 512, 512);
+        reqHandler.mirrorRegionDef(pixels, new Dimension(512, 512), regionDef);
+        Assert.assertEquals(regionDef.getX(), 256);
+        Assert.assertEquals(regionDef.getY(), 0);
+        Assert.assertEquals(regionDef.getWidth(), 512);
+        Assert.assertEquals(regionDef.getHeight(), 256);
+
+        // Tile 1, 1
+        regionDef = new RegionDef(512, 512, 512, 512);
+        reqHandler.mirrorRegionDef(pixels, new Dimension(512, 512), regionDef);
+        Assert.assertEquals(regionDef.getX(), 0);
+        Assert.assertEquals(regionDef.getY(), 0);
+        Assert.assertEquals(regionDef.getWidth(), 256);
+        Assert.assertEquals(regionDef.getHeight(), 256);
     }
 
 }

--- a/src/test/java/com/glencoesoftware/omero/ms/image/region/ImageRegionRequestHandlerTest.java
+++ b/src/test/java/com/glencoesoftware/omero/ms/image/region/ImageRegionRequestHandlerTest.java
@@ -64,7 +64,8 @@ public class ImageRegionRequestHandlerTest {
     }
 
     private void testFlip(
-            int[] src, int sizeX, int sizeY, boolean flipHorizontal, boolean flipVertical) {
+            int[] src, int sizeX, int sizeY,
+            boolean flipHorizontal, boolean flipVertical) {
         int[] flipped = ImageRegionRequestHandler.flip(
                 src, sizeX, sizeY, flipHorizontal, flipVertical);
         for (int n = 0; n < sizeX * sizeY; n++){

--- a/src/test/java/com/glencoesoftware/omero/ms/image/region/ImageRegionRequestHandlerTest.java
+++ b/src/test/java/com/glencoesoftware/omero/ms/image/region/ImageRegionRequestHandlerTest.java
@@ -26,6 +26,8 @@ import org.testng.annotations.Test;
 import org.testng.Assert;
 import org.testng.annotations.BeforeMethod;
 
+import omeis.providers.re.data.RegionDef;
+
 public class ImageRegionRequestHandlerTest {
 
     @BeforeMethod
@@ -167,5 +169,131 @@ public class ImageRegionRequestHandlerTest {
     public void testMirrorZeroYImage() {
         int[] src = {1};
         ImageRegionRequestHandler.mirror(src, 4, 0, true, true);
+    }
+
+    @Test
+    public void testGetMirroredRegionDef() {
+        RegionDef originalRegion = new RegionDef(1,1,256,256);
+        RegionDef finalDef = ImageRegionRequestHandler.getMirroredRegionDef(
+            1024,
+            1024,
+            originalRegion.getWidth(),
+            originalRegion.getHeight(),
+            originalRegion.getX(),
+            originalRegion.getY(),
+            false,
+            false);
+        Assert.assertEquals(1, finalDef.getX());
+        Assert.assertEquals(1, finalDef.getY());
+        Assert.assertEquals(256, finalDef.getWidth());
+        Assert.assertEquals(256, finalDef.getHeight());
+    }
+
+    @Test
+    public void testGetMirroredRegionDefX() {
+        RegionDef originalRegion = new RegionDef(1,1,256,256);
+        RegionDef finalDef = ImageRegionRequestHandler.getMirroredRegionDef(
+            1024,
+            1024,
+            originalRegion.getWidth(),
+            originalRegion.getHeight(),
+            originalRegion.getX(),
+            originalRegion.getY(),
+            true,
+            false);
+        Assert.assertEquals(2, finalDef.getX());
+        Assert.assertEquals(1, finalDef.getY());
+        Assert.assertEquals(256, finalDef.getWidth());
+        Assert.assertEquals(256, finalDef.getHeight());
+    }
+
+    @Test
+    public void testGetMirroredRegionDefY() {
+        RegionDef originalRegion = new RegionDef(1,1,256,256);
+        RegionDef finalDef = ImageRegionRequestHandler.getMirroredRegionDef(
+            1024,
+            1024,
+            originalRegion.getWidth(),
+            originalRegion.getHeight(),
+            originalRegion.getX(),
+            originalRegion.getY(),
+            false,
+            true);
+        Assert.assertEquals(finalDef.getX(), 1);
+        Assert.assertEquals(finalDef.getY(), 2);
+        Assert.assertEquals(finalDef.getWidth(), 256);
+        Assert.assertEquals(finalDef.getHeight(), 256);
+    }
+
+    @Test
+    public void testGetMirroredRegionDefXY() {
+        RegionDef originalRegion = new RegionDef(1,1,256,256);
+        RegionDef finalDef = ImageRegionRequestHandler.getMirroredRegionDef(
+            1024,
+            1024,
+            originalRegion.getWidth(),
+            originalRegion.getHeight(),
+            originalRegion.getX(),
+            originalRegion.getY(),
+            true,
+            true);
+        Assert.assertEquals(finalDef.getX(), 2);
+        Assert.assertEquals(finalDef.getY(), 2);
+        Assert.assertEquals(finalDef.getWidth(), 256);
+        Assert.assertEquals(finalDef.getHeight(), 256);
+    }
+
+    @Test
+    public void testGetMirroredRegionDefXEdge() {
+        RegionDef originalRegion = new RegionDef(0,1,256,256);
+        RegionDef finalDef = ImageRegionRequestHandler.getMirroredRegionDef(
+            1023,
+            1024,
+            originalRegion.getWidth(),
+            originalRegion.getHeight(),
+            originalRegion.getX(),
+            originalRegion.getY(),
+            true,
+            false);
+        Assert.assertEquals(finalDef.getX(), 3);
+        Assert.assertEquals(1, finalDef.getY(), 1);
+        Assert.assertEquals(finalDef.getWidth(), 255);
+        Assert.assertEquals(finalDef.getHeight(), 256);
+    }
+
+    @Test
+    public void testGetMirroredRegionDefYEdge() {
+        RegionDef originalRegion = new RegionDef(1,0,256,256);
+        RegionDef finalDef = ImageRegionRequestHandler.getMirroredRegionDef(
+            1024,
+            1023,
+            originalRegion.getWidth(),
+            originalRegion.getHeight(),
+            originalRegion.getX(),
+            originalRegion.getY(),
+            false,
+            true);
+        Assert.assertEquals(finalDef.getX(), 1);
+        Assert.assertEquals(finalDef.getY(), 3);
+        Assert.assertEquals(finalDef.getWidth(), 256);
+        Assert.assertEquals(finalDef.getHeight(), 255);
+    }
+
+    @Test
+    public void testGetMirroredRegionDefXYEdge() {
+        RegionDef originalRegion = new RegionDef(0,0,256,256);
+        RegionDef finalDef = ImageRegionRequestHandler.getMirroredRegionDef(
+            1023,
+            1023,
+            originalRegion.getWidth(),
+            originalRegion.getHeight(),
+            originalRegion.getX(),
+            originalRegion.getY(),
+            true,
+            true);
+        Assert.assertEquals(finalDef.getX(), 3);
+        Assert.assertEquals(finalDef.getY(), 3);
+        Assert.assertEquals(finalDef.getWidth(), 255);
+        Assert.assertEquals(finalDef.getHeight(), 255);
     }
 }

--- a/src/test/java/com/glencoesoftware/omero/ms/image/region/ImageRegionRequestHandlerTest.java
+++ b/src/test/java/com/glencoesoftware/omero/ms/image/region/ImageRegionRequestHandlerTest.java
@@ -55,11 +55,7 @@ public class ImageRegionRequestHandlerTest {
         params.add("imageId", "1");
         params.add("theZ", "0");
         params.add("theT", "0");
-        params.add("tile", "0,0,0");
-        params.add("region","0,0,1,1");
-        params.add("c", "-1|0:65535$0000FF,2|1755:51199$00FF00,3|3218:26623$FF0000");
-        params.add("m", "");
-        params.add("mirror", "");
+        params.add("m", "rgb");
 
         imageRegionCtx = new ImageRegionCtx(params, "");
         reqHandler = new ImageRegionRequestHandler(
@@ -357,7 +353,6 @@ public class ImageRegionRequestHandlerTest {
     @Test
     public void testGetRegionDefCtxRegion()
         throws IllegalArgumentException, ServerError {
-        imageRegionCtx.tile = null;
         imageRegionCtx.region = new RegionDef(512, 512, 256, 256);
         Pixels pixels = new Pixels();
         pixels.setSizeX(1024);
@@ -374,8 +369,6 @@ public class ImageRegionRequestHandlerTest {
     @Test
     public void testGetRegionDefCtxNoTileOrRegion()
         throws IllegalArgumentException, ServerError {
-        imageRegionCtx.tile = null;
-        imageRegionCtx.region = null;
         Pixels pixels = new Pixels();
         pixels.setSizeX(1024);
         pixels.setSizeY(1024);

--- a/src/test/java/com/glencoesoftware/omero/ms/image/region/ImageRegionRequestHandlerTest.java
+++ b/src/test/java/com/glencoesoftware/omero/ms/image/region/ImageRegionRequestHandlerTest.java
@@ -21,7 +21,6 @@ package com.glencoesoftware.omero.ms.image.region;
 import static org.mockito.Mockito.*;
 
 import java.util.ArrayList;
-import java.lang.Integer;
 import java.awt.Dimension;
 
 import io.vertx.core.MultiMap;
@@ -341,13 +340,13 @@ public class ImageRegionRequestHandlerTest {
         pixels.setSizeX(1024);
         pixels.setSizeY(1024);
         PixelBuffer pixelBuffer = mock(PixelBuffer.class);
-        int tileSide = 256;
-        when(pixelBuffer.getTileSize()).thenReturn(new Dimension(tileSide, tileSide));
+        int tileSize = 256;
+        when(pixelBuffer.getTileSize()).thenReturn(new Dimension(tileSize, tileSize));
         RegionDef rdef = reqHandler.getRegionDef(pixels, pixelBuffer);
-        Assert.assertEquals(rdef.getX(), x*tileSide);
-        Assert.assertEquals(rdef.getX(), y*tileSide);
-        Assert.assertEquals(rdef.getWidth(), tileSide);
-        Assert.assertEquals(rdef.getHeight(), tileSide);
+        Assert.assertEquals(rdef.getX(), x * tileSize);
+        Assert.assertEquals(rdef.getX(), y * tileSize);
+        Assert.assertEquals(rdef.getWidth(), tileSize);
+        Assert.assertEquals(rdef.getHeight(), tileSize);
     }
 
     @Test

--- a/src/test/java/com/glencoesoftware/omero/ms/image/region/ImageRegionRequestHandlerTest.java
+++ b/src/test/java/com/glencoesoftware/omero/ms/image/region/ImageRegionRequestHandlerTest.java
@@ -35,6 +35,8 @@ import org.testng.annotations.BeforeMethod;
 import omeis.providers.re.data.RegionDef;
 import ome.io.nio.PixelBuffer;
 import ome.model.core.Pixels;
+import ome.model.enums.Family;
+import ome.model.enums.RenderingModel;
 
 import omero.ServerError;
 
@@ -62,8 +64,8 @@ public class ImageRegionRequestHandlerTest {
         reqHandler = new ImageRegionRequestHandler(
                 imageRegionCtx,
                 null, //ApplicationContext context,
-                new ArrayList(), //List<Family> families,
-                new ArrayList(), //List<RenderingModel> renderingModels,
+                new ArrayList<Family>(),
+                new ArrayList<RenderingModel>(),
                 null, //LutProvider lutProvider,
                 null, //LocalCompress compSrv,
                 null); //PixelsService pixService);

--- a/src/test/java/com/glencoesoftware/omero/ms/image/region/ImageRegionRequestHandlerTest.java
+++ b/src/test/java/com/glencoesoftware/omero/ms/image/region/ImageRegionRequestHandlerTest.java
@@ -44,8 +44,9 @@ import omero.ServerError;
 
 public class ImageRegionRequestHandlerTest {
 
-    private ImageRegionCtx imageRegionCtx = null;
-    private ImageRegionRequestHandler reqHandler = null;
+    private ImageRegionCtx imageRegionCtx;
+
+    private ImageRegionRequestHandler reqHandler;
 
     @BeforeMethod
     public void setUp() {

--- a/src/test/java/com/glencoesoftware/omero/ms/image/region/ImageRegionRequestHandlerTest.java
+++ b/src/test/java/com/glencoesoftware/omero/ms/image/region/ImageRegionRequestHandlerTest.java
@@ -63,135 +63,135 @@ public class ImageRegionRequestHandlerTest {
                 null); //PixelsService pixService);
     }
 
-    private void testMirror(
-            int[] src, int sizeX, int sizeY, boolean mirrorX, boolean mirrorY) {
-        int[] mirrored = ImageRegionRequestHandler.mirror(
-                src, sizeX, sizeY, mirrorX, mirrorY);
+    private void testFlip(
+            int[] src, int sizeX, int sizeY, boolean flipHorizontal, boolean flipVertical) {
+        int[] flipped = ImageRegionRequestHandler.flip(
+                src, sizeX, sizeY, flipHorizontal, flipVertical);
         for (int n = 0; n < sizeX * sizeY; n++){
             int new_col;
-            if (mirrorX) {
+            if (flipHorizontal) {
                 int old_col = n % sizeX;
                 new_col = sizeX - 1 - old_col;
             } else {
                 new_col = n % sizeX;
             }
             int new_row;
-            if (mirrorY) {
+            if (flipVertical) {
                 int old_row = n / sizeX;
                 new_row = sizeY - 1 - old_row;
             } else {
                 new_row = n / sizeX;
             }
-            Assert.assertEquals(mirrored[new_row * sizeX + new_col], n);
+            Assert.assertEquals(flipped[new_row * sizeX + new_col], n);
         }
     }
 
-    private void testAllMirrors(int[] src, int sizeX, int sizeY) {
-        boolean mirrorX = false;
-        boolean mirrorY = true;
-        testMirror(src, sizeX, sizeY, mirrorX, mirrorY);
+    private void testAllFlips(int[] src, int sizeX, int sizeY) {
+        boolean flipHorizontal = false;
+        boolean flipVertical = true;
+        testFlip(src, sizeX, sizeY, flipHorizontal, flipVertical);
 
-        mirrorX = true; 
-        mirrorY = false;
-        testMirror(src, sizeX, sizeY, mirrorX, mirrorY);
+        flipHorizontal = true;
+        flipVertical = false;
+        testFlip(src, sizeX, sizeY, flipHorizontal, flipVertical);
 
-        mirrorX = true; 
-        mirrorY = true;
-        testMirror(src, sizeX, sizeY, mirrorX, mirrorY);
+        flipHorizontal = true;
+        flipVertical = true;
+        testFlip(src, sizeX, sizeY, flipHorizontal, flipVertical);
     }
 
     @Test
-    public void testMirrorEvenSquare2() {
+    public void testFlipEvenSquare2() {
         int sizeX = 4;
         int sizeY = 4;
         int[] src = new int[sizeX * sizeY];
         for (int n = 0; n < sizeX * sizeY; n++){
             src[n] = n;
         }
-        testAllMirrors(src, sizeX, sizeY);
+        testAllFlips(src, sizeX, sizeY);
     }
 
     @Test
-    public void testMirrorOddSquare(){
+    public void testFlipOddSquare(){
         int sizeX = 5;
         int sizeY = 5;
         int[] src = new int[sizeX * sizeY];
         for (int n = 0; n < sizeX * sizeY; n++){
             src[n] = n;
         }
-        testAllMirrors(src, sizeX, sizeY);
+        testAllFlips(src, sizeX, sizeY);
     }
 
     @Test
-    public void testMirrorWideRectangle() {
+    public void testFlipWideRectangle() {
         int sizeX = 7;
         int sizeY = 4;
         int[] src = new int[sizeX * sizeY];
         for (int n = 0; n < sizeX * sizeY; n++){
             src[n] = n;
         }
-        testAllMirrors(src, sizeX, sizeY);
+        testAllFlips(src, sizeX, sizeY);
     }
 
     @Test
-    public void testMirrorTallRectangle() {
+    public void testFlipTallRectangle() {
         int sizeX = 4;
         int sizeY = 7;
         int[] src = new int[sizeX * sizeY];
         for (int n = 0; n < sizeX * sizeY; n++){
             src[n] = n;
         }
-        testAllMirrors(src, sizeX, sizeY);
+        testAllFlips(src, sizeX, sizeY);
     }
 
     @Test
-    public void testMirrorSingleWidthRectangle() {
+    public void testFlipSingleWidthRectangle() {
         int sizeX = 7;
         int sizeY = 1;
         int[] src = new int[sizeX * sizeY];
         for (int n = 0; n < sizeX * sizeY; n++){
             src[n] = n;
         }
-        testAllMirrors(src, sizeX, sizeY);
+        testAllFlips(src, sizeX, sizeY);
     }
 
     @Test
-    public void testMirrorSingleHeightRectangle() {
+    public void testFlipSingleHeightRectangle() {
         int sizeX = 1;
         int sizeY = 7;
         int[] src = new int[sizeX * sizeY];
         for (int n = 0; n < sizeX * sizeY; n++){
             src[n] = n;
         }
-        testAllMirrors(src, sizeX, sizeY);
+        testAllFlips(src, sizeX, sizeY);
     }
 
     @Test
-    public void testMirrorSingleEntry() {
+    public void testFlipSingleEntry() {
         int sizeX = 1;
         int sizeY = 1;
         int[] src = new int[sizeX * sizeY];
         for (int n = 0; n < sizeX * sizeY; n++){
             src[n] = n;
         }
-        testAllMirrors(src, sizeX, sizeY);
+        testAllFlips(src, sizeX, sizeY);
     }
 
     @Test(expectedExceptions = IllegalArgumentException.class)
-    public void testMirrorNullImage() {
-        ImageRegionRequestHandler.mirror(null, 4, 4, true, true);
+    public void testFlipNullImage() {
+        ImageRegionRequestHandler.flip(null, 4, 4, true, true);
     }
 
     @Test(expectedExceptions = IllegalArgumentException.class)
-    public void testMirrorZeroXImage() {
+    public void testFlipZeroXImage() {
         int[] src = {1};
-        ImageRegionRequestHandler.mirror(src, 0, 4, true, true);
+        ImageRegionRequestHandler.flip(src, 0, 4, true, true);
     }
 
     @Test(expectedExceptions = IllegalArgumentException.class)
-    public void testMirrorZeroYImage() {
+    public void testFlipZeroYImage() {
         int[] src = {1};
-        ImageRegionRequestHandler.mirror(src, 4, 0, true, true);
+        ImageRegionRequestHandler.flip(src, 4, 0, true, true);
     }
 
     @Test
@@ -363,17 +363,17 @@ public class ImageRegionRequestHandlerTest {
                 rdef.getHeight(), 1024 - rdef.getY());
     }
 
-//Test Mirroring
+//Test Flipping
     @Test
-    public void testMirrorRegionDefMirrorX() throws ServerError{
+    public void testFlipRegionDefFlipH() throws ServerError{
         Pixels pixels = new Pixels();
         pixels.setSizeX(1024);
         pixels.setSizeY(1024);
         PixelBuffer pixelBuffer = mock(PixelBuffer.class);
         when(pixelBuffer.getTileSize()).thenReturn(new Dimension(256, 256));
         imageRegionCtx.region = new RegionDef(100, 200, 300, 400);
-        imageRegionCtx.mirrorX = true;
-        imageRegionCtx.mirrorY = false;
+        imageRegionCtx.flipHorizontal = true;
+        imageRegionCtx.flipVertical = false;
         RegionDef regionDef = reqHandler.getRegionDef(pixels, pixelBuffer);
         Assert.assertEquals(regionDef.getX(), 624);
         Assert.assertEquals(regionDef.getY(), 200);
@@ -382,15 +382,15 @@ public class ImageRegionRequestHandlerTest {
     }
 
     @Test
-    public void testMirrorRegionDefMirrorY() throws ServerError{
+    public void testFlipRegionDefFlipV() throws ServerError{
         Pixels pixels = new Pixels();
         pixels.setSizeX(1024);
         pixels.setSizeY(1024);
         PixelBuffer pixelBuffer = mock(PixelBuffer.class);
         when(pixelBuffer.getTileSize()).thenReturn(new Dimension(256, 256));
         imageRegionCtx.region = new RegionDef(100, 200, 300, 400);
-        imageRegionCtx.mirrorX = false;
-        imageRegionCtx.mirrorY = true;
+        imageRegionCtx.flipHorizontal = false;
+        imageRegionCtx.flipVertical = true;
         RegionDef regionDef = reqHandler.getRegionDef(pixels, pixelBuffer);
         Assert.assertEquals(regionDef.getX(), 100);
         Assert.assertEquals(regionDef.getY(), 424);
@@ -399,15 +399,15 @@ public class ImageRegionRequestHandlerTest {
     }
 
     @Test
-    public void testMirrorRegionDefMirrorXY() throws ServerError{
+    public void testFlipRegionDefFlipHV() throws ServerError{
         Pixels pixels = new Pixels();
         pixels.setSizeX(1024);
         pixels.setSizeY(1024);
         PixelBuffer pixelBuffer = mock(PixelBuffer.class);
         when(pixelBuffer.getTileSize()).thenReturn(new Dimension(256, 256));
         imageRegionCtx.region = new RegionDef(100, 200, 300, 400);
-        imageRegionCtx.mirrorX = true;
-        imageRegionCtx.mirrorY = true;
+        imageRegionCtx.flipHorizontal = true;
+        imageRegionCtx.flipVertical = true;
         RegionDef regionDef = reqHandler.getRegionDef(pixels, pixelBuffer);
         Assert.assertEquals(regionDef.getX(), 624);
         Assert.assertEquals(regionDef.getY(), 424);
@@ -416,7 +416,7 @@ public class ImageRegionRequestHandlerTest {
     }
 
     @Test
-    public void testMirrorRegionDefMirorXEdge() throws ServerError{
+    public void testFlipRegionDefMirorXEdge() throws ServerError{
         // Tile 0, 0
         imageRegionCtx.region = new RegionDef(0, 0, 1024, 1024);
         Pixels pixels = new Pixels();
@@ -424,8 +424,8 @@ public class ImageRegionRequestHandlerTest {
         pixels.setSizeY(768);
         PixelBuffer pixelBuffer = mock(PixelBuffer.class);
         when(pixelBuffer.getTileSize()).thenReturn(new Dimension(512, 512));
-        imageRegionCtx.mirrorX = true;
-        imageRegionCtx.mirrorY = false;
+        imageRegionCtx.flipHorizontal = true;
+        imageRegionCtx.flipVertical = false;
         RegionDef regionDef = reqHandler.getRegionDef(pixels, pixelBuffer);
         Assert.assertEquals(regionDef.getX(), 0);
         Assert.assertEquals(regionDef.getY(), 0);
@@ -458,7 +458,7 @@ public class ImageRegionRequestHandlerTest {
     }
 
     @Test
-    public void testMirrorRegionDefMirorYEdge() throws ServerError{
+    public void testFlipRegionDefMirorYEdge() throws ServerError{
         // Tile 0, 0
         imageRegionCtx.region = new RegionDef(0, 0, 512, 512);
         Pixels pixels = new Pixels();
@@ -466,7 +466,7 @@ public class ImageRegionRequestHandlerTest {
         pixels.setSizeY(768);
         PixelBuffer pixelBuffer = mock(PixelBuffer.class);
         when(pixelBuffer.getTileSize()).thenReturn(new Dimension(512, 512));
-        imageRegionCtx.mirrorY = true;
+        imageRegionCtx.flipVertical = true;
         RegionDef regionDef = reqHandler.getRegionDef(pixels, pixelBuffer);
         Assert.assertEquals(regionDef.getX(), 0);
         Assert.assertEquals(regionDef.getY(), 256);
@@ -499,7 +499,7 @@ public class ImageRegionRequestHandlerTest {
     }
 
     @Test
-    public void testMirrorRegionDefMirorXYEdge() throws ServerError{
+    public void testFlipRegionDefMirorXYEdge() throws ServerError{
         // Tile 0, 0
         imageRegionCtx.region = new RegionDef(0, 0, 512, 512);
         Pixels pixels = new Pixels();
@@ -507,8 +507,8 @@ public class ImageRegionRequestHandlerTest {
         pixels.setSizeY(768);
         PixelBuffer pixelBuffer = mock(PixelBuffer.class);
         when(pixelBuffer.getTileSize()).thenReturn(new Dimension(512, 512));
-        imageRegionCtx.mirrorX = true;
-        imageRegionCtx.mirrorY = true;
+        imageRegionCtx.flipHorizontal = true;
+        imageRegionCtx.flipVertical = true;
         RegionDef regionDef = reqHandler.getRegionDef(pixels, pixelBuffer);
         Assert.assertEquals(regionDef.getX(), 256);
         Assert.assertEquals(regionDef.getY(), 256);

--- a/src/test/java/com/glencoesoftware/omero/ms/image/region/ImageRegionRequestHandlerTest.java
+++ b/src/test/java/com/glencoesoftware/omero/ms/image/region/ImageRegionRequestHandlerTest.java
@@ -340,9 +340,9 @@ public class ImageRegionRequestHandlerTest {
         int x = 2;
         int y = 2;
         imageRegionCtx.tile = new RegionDef(x, y, 0, 0);
-        Pixels pixels = mock(Pixels.class);
-        when(pixels.getSizeX()).thenReturn(new Integer(1024));
-        when(pixels.getSizeY()).thenReturn(new Integer(1024));
+        Pixels pixels = new Pixels();
+        pixels.setSizeX(1024);
+        pixels.setSizeY(1024);
         PixelBuffer pixelBuffer = mock(PixelBuffer.class);
         int tileSide = 256;
         when(pixelBuffer.getTileSize()).thenReturn(new Dimension(tileSide, tileSide));
@@ -358,9 +358,9 @@ public class ImageRegionRequestHandlerTest {
         throws IllegalArgumentException, ServerError {
         imageRegionCtx.tile = null;
         imageRegionCtx.region = new RegionDef(512, 512, 256, 256);
-        Pixels pixels = mock(Pixels.class);
-        when(pixels.getSizeX()).thenReturn(new Integer(1024));
-        when(pixels.getSizeY()).thenReturn(new Integer(1024));
+        Pixels pixels = new Pixels();
+        pixels.setSizeX(1024);
+        pixels.setSizeY(1024);
         PixelBuffer pixelBuffer = mock(PixelBuffer.class);
         when(pixelBuffer.getTileSize()).thenReturn(new Dimension(256,256));
         RegionDef rdef = reqHandler.getRegionDef(pixels, pixelBuffer);
@@ -375,9 +375,9 @@ public class ImageRegionRequestHandlerTest {
         throws IllegalArgumentException, ServerError {
         imageRegionCtx.tile = null;
         imageRegionCtx.region = null;
-        Pixels pixels = mock(Pixels.class);
-        when(pixels.getSizeX()).thenReturn(new Integer(1024));
-        when(pixels.getSizeY()).thenReturn(new Integer(1024));
+        Pixels pixels = new Pixels();
+        pixels.setSizeX(1024);
+        pixels.setSizeY(1024);
         PixelBuffer pixelBuffer = mock(PixelBuffer.class);
         when(pixelBuffer.getTileSize()).thenReturn(new Dimension(256,256));
         RegionDef rdef = reqHandler.getRegionDef(pixels, pixelBuffer);

--- a/src/test/java/com/glencoesoftware/omero/ms/image/region/ImageRegionRequestHandlerTest.java
+++ b/src/test/java/com/glencoesoftware/omero/ms/image/region/ImageRegionRequestHandlerTest.java
@@ -344,7 +344,7 @@ public class ImageRegionRequestHandlerTest {
         when(pixelBuffer.getTileSize()).thenReturn(new Dimension(tileSize, tileSize));
         RegionDef rdef = reqHandler.getRegionDef(pixels, pixelBuffer);
         Assert.assertEquals(rdef.getX(), x * tileSize);
-        Assert.assertEquals(rdef.getX(), y * tileSize);
+        Assert.assertEquals(rdef.getY(), y * tileSize);
         Assert.assertEquals(rdef.getWidth(), tileSize);
         Assert.assertEquals(rdef.getHeight(), tileSize);
     }
@@ -360,7 +360,7 @@ public class ImageRegionRequestHandlerTest {
         when(pixelBuffer.getTileSize()).thenReturn(new Dimension(256,256));
         RegionDef rdef = reqHandler.getRegionDef(pixels, pixelBuffer);
         Assert.assertEquals(rdef.getX(), imageRegionCtx.region.getX());
-        Assert.assertEquals(rdef.getX(), imageRegionCtx.region.getY());
+        Assert.assertEquals(rdef.getY(), imageRegionCtx.region.getY());
         Assert.assertEquals(rdef.getWidth(), imageRegionCtx.region.getWidth());
         Assert.assertEquals(rdef.getHeight(), imageRegionCtx.region.getHeight());
     }
@@ -375,7 +375,7 @@ public class ImageRegionRequestHandlerTest {
         when(pixelBuffer.getTileSize()).thenReturn(new Dimension(256,256));
         RegionDef rdef = reqHandler.getRegionDef(pixels, pixelBuffer);
         Assert.assertEquals(rdef.getX(), 0);
-        Assert.assertEquals(rdef.getX(), 0);
+        Assert.assertEquals(rdef.getY(), 0);
         Assert.assertEquals(rdef.getWidth(), 1024);
         Assert.assertEquals(rdef.getHeight(), 1024);
     }

--- a/src/test/java/com/glencoesoftware/omero/ms/image/region/ImageRegionRequestHandlerTest.java
+++ b/src/test/java/com/glencoesoftware/omero/ms/image/region/ImageRegionRequestHandlerTest.java
@@ -1,0 +1,154 @@
+/*
+ * Copyright (C) 2017 Glencoe Software, Inc. All rights reserved.
+ *
+ * This program is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation; either version 2 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License along
+ * with this program; if not, write to the Free Software Foundation, Inc.,
+ * 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
+ */
+
+package com.glencoesoftware.omero.ms.image.region;
+
+import java.io.IOException;
+import java.util.Map;
+
+import org.testng.annotations.Test;
+
+import org.testng.Assert;
+import org.testng.annotations.BeforeMethod;
+
+public class ImageRegionRequestHandlerTest {
+
+    @BeforeMethod
+    public void setUp() {
+    }
+
+    private void testMirror(int[] src,
+        int sizeX,
+        int sizeY,
+        boolean mirrorX,
+        boolean mirrorY) {
+        int[] mirrored = ImageRegionRequestHandler.mirror(src, sizeX, sizeY, mirrorX, mirrorY);
+        for (int n = 0; n < sizeX*sizeY; n++){
+            int new_col;
+            if (mirrorX) {
+                int old_col = n % sizeX;
+                new_col = sizeX - 1 - old_col;
+            }
+            else {
+                new_col = n % sizeX;
+            }
+            int new_row;
+            if (mirrorY) {
+                int old_row = n / sizeX;
+                new_row = sizeY - 1 - old_row;
+            }
+            else {
+                new_row = n / sizeX;
+            }
+            Assert.assertEquals(mirrored[new_row*sizeX + new_col], n);
+        }
+    }
+
+    private void testAllMirrors(int[] src,
+        int sizeX,
+        int sizeY) {
+        boolean mirrorX = false;
+        boolean mirrorY = true;
+        testMirror(src, sizeX, sizeY, mirrorX, mirrorY);
+
+        mirrorX = true; 
+        mirrorY = false;
+        testMirror(src, sizeX, sizeY, mirrorX, mirrorY);
+
+        mirrorX = true; 
+        mirrorY = true;
+        testMirror(src, sizeX, sizeY, mirrorX, mirrorY);
+    }
+
+    @Test
+    public void testMirrorEvenSquare2() {
+        int sizeX = 4;
+        int sizeY = 4;
+        int[] src = new int[sizeX*sizeY];
+        for (int n = 0; n < sizeX*sizeY; n++){
+            src[n] = n;
+        }
+        testAllMirrors(src, sizeX, sizeY);
+    }
+
+    @Test
+    public void testMirrorOddSquare(){
+        int sizeX = 5;
+        int sizeY = 5;
+        int[] src = new int[sizeX*sizeY];
+        for (int n = 0; n < sizeX*sizeY; n++){
+            src[n] = n;
+        }
+        testAllMirrors(src, sizeX, sizeY);
+    }
+
+    @Test
+    public void testMirrorWideRectangle() {
+        int sizeX = 7;
+        int sizeY = 4;
+        int[] src = new int[sizeX*sizeY];
+        for (int n = 0; n < sizeX*sizeY; n++){
+            src[n] = n;
+        }
+        testAllMirrors(src, sizeX, sizeY);
+    }
+
+    @Test
+    public void testMirrorTallRectangle() {
+        int sizeX = 4;
+        int sizeY = 7;
+        int[] src = new int[sizeX*sizeY];
+        for (int n = 0; n < sizeX*sizeY; n++){
+            src[n] = n;
+        }
+        testAllMirrors(src, sizeX, sizeY);
+    }
+
+    @Test
+    public void testMirrorSingleWidthRectangle() {
+        int sizeX = 7;
+        int sizeY = 1;
+        int[] src = new int[sizeX*sizeY];
+        for (int n = 0; n < sizeX*sizeY; n++){
+            src[n] = n;
+        }
+        testAllMirrors(src, sizeX, sizeY);
+    }
+
+    @Test
+    public void testMirrorSingleHeightRectangle() {
+        int sizeX = 1;
+        int sizeY = 7;
+        int[] src = new int[sizeX*sizeY];
+        for (int n = 0; n < sizeX*sizeY; n++){
+            src[n] = n;
+        }
+        testAllMirrors(src, sizeX, sizeY);
+    }
+
+    @Test
+    public void testMirrorSingleEntry() {
+        int sizeX = 1;
+        int sizeY = 1;
+        int[] src = new int[sizeX*sizeY];
+        for (int n = 0; n < sizeX*sizeY; n++){
+            src[n] = n;
+        }
+        testAllMirrors(src, sizeX, sizeY);
+    }
+}

--- a/src/test/java/com/glencoesoftware/omero/ms/image/region/ImageRegionRequestHandlerTest.java
+++ b/src/test/java/com/glencoesoftware/omero/ms/image/region/ImageRegionRequestHandlerTest.java
@@ -20,25 +20,21 @@ package com.glencoesoftware.omero.ms.image.region;
 
 import static org.mockito.Mockito.*;
 
-import java.util.ArrayList;
 import java.awt.Dimension;
-
-import io.vertx.core.MultiMap;
-import io.vertx.core.http.CaseInsensitiveHeaders;
-
-import org.testng.annotations.Test;
+import java.util.ArrayList;
 
 import org.testng.Assert;
 import org.testng.annotations.BeforeMethod;
+import org.testng.annotations.Test;
 
-import omeis.providers.re.data.RegionDef;
+import io.vertx.core.MultiMap;
+import io.vertx.core.http.CaseInsensitiveHeaders;
+import omero.ServerError;
 import ome.io.nio.PixelBuffer;
 import ome.model.core.Pixels;
 import ome.model.enums.Family;
 import ome.model.enums.RenderingModel;
-
-import omero.ServerError;
-
+import omeis.providers.re.data.RegionDef;
 
 
 public class ImageRegionRequestHandlerTest {
@@ -67,12 +63,10 @@ public class ImageRegionRequestHandlerTest {
                 null); //PixelsService pixService);
     }
 
-    private void testMirror(int[] src,
-        int sizeX,
-        int sizeY,
-        boolean mirrorX,
-        boolean mirrorY) {
-        int[] mirrored = ImageRegionRequestHandler.mirror(src, sizeX, sizeY, mirrorX, mirrorY);
+    private void testMirror(
+            int[] src, int sizeX, int sizeY, boolean mirrorX, boolean mirrorY) {
+        int[] mirrored = ImageRegionRequestHandler.mirror(
+                src, sizeX, sizeY, mirrorX, mirrorY);
         for (int n = 0; n < sizeX*sizeY; n++){
             int new_col;
             if (mirrorX) {
@@ -90,13 +84,11 @@ public class ImageRegionRequestHandlerTest {
             else {
                 new_row = n / sizeX;
             }
-            Assert.assertEquals(mirrored[new_row*sizeX + new_col], n);
+            Assert.assertEquals(mirrored[new_row * sizeX + new_col], n);
         }
     }
 
-    private void testAllMirrors(int[] src,
-        int sizeX,
-        int sizeY) {
+    private void testAllMirrors(int[] src, int sizeX, int sizeY) {
         boolean mirrorX = false;
         boolean mirrorY = true;
         testMirror(src, sizeX, sizeY, mirrorX, mirrorY);
@@ -114,8 +106,8 @@ public class ImageRegionRequestHandlerTest {
     public void testMirrorEvenSquare2() {
         int sizeX = 4;
         int sizeY = 4;
-        int[] src = new int[sizeX*sizeY];
-        for (int n = 0; n < sizeX*sizeY; n++){
+        int[] src = new int[sizeX * sizeY];
+        for (int n = 0; n < sizeX * sizeY; n++){
             src[n] = n;
         }
         testAllMirrors(src, sizeX, sizeY);
@@ -125,8 +117,8 @@ public class ImageRegionRequestHandlerTest {
     public void testMirrorOddSquare(){
         int sizeX = 5;
         int sizeY = 5;
-        int[] src = new int[sizeX*sizeY];
-        for (int n = 0; n < sizeX*sizeY; n++){
+        int[] src = new int[sizeX * sizeY];
+        for (int n = 0; n < sizeX * sizeY; n++){
             src[n] = n;
         }
         testAllMirrors(src, sizeX, sizeY);
@@ -136,8 +128,8 @@ public class ImageRegionRequestHandlerTest {
     public void testMirrorWideRectangle() {
         int sizeX = 7;
         int sizeY = 4;
-        int[] src = new int[sizeX*sizeY];
-        for (int n = 0; n < sizeX*sizeY; n++){
+        int[] src = new int[sizeX * sizeY];
+        for (int n = 0; n < sizeX * sizeY; n++){
             src[n] = n;
         }
         testAllMirrors(src, sizeX, sizeY);
@@ -147,8 +139,8 @@ public class ImageRegionRequestHandlerTest {
     public void testMirrorTallRectangle() {
         int sizeX = 4;
         int sizeY = 7;
-        int[] src = new int[sizeX*sizeY];
-        for (int n = 0; n < sizeX*sizeY; n++){
+        int[] src = new int[sizeX * sizeY];
+        for (int n = 0; n < sizeX * sizeY; n++){
             src[n] = n;
         }
         testAllMirrors(src, sizeX, sizeY);
@@ -158,8 +150,8 @@ public class ImageRegionRequestHandlerTest {
     public void testMirrorSingleWidthRectangle() {
         int sizeX = 7;
         int sizeY = 1;
-        int[] src = new int[sizeX*sizeY];
-        for (int n = 0; n < sizeX*sizeY; n++){
+        int[] src = new int[sizeX * sizeY];
+        for (int n = 0; n < sizeX * sizeY; n++){
             src[n] = n;
         }
         testAllMirrors(src, sizeX, sizeY);
@@ -169,8 +161,8 @@ public class ImageRegionRequestHandlerTest {
     public void testMirrorSingleHeightRectangle() {
         int sizeX = 1;
         int sizeY = 7;
-        int[] src = new int[sizeX*sizeY];
-        for (int n = 0; n < sizeX*sizeY; n++){
+        int[] src = new int[sizeX * sizeY];
+        for (int n = 0; n < sizeX * sizeY; n++){
             src[n] = n;
         }
         testAllMirrors(src, sizeX, sizeY);
@@ -180,25 +172,25 @@ public class ImageRegionRequestHandlerTest {
     public void testMirrorSingleEntry() {
         int sizeX = 1;
         int sizeY = 1;
-        int[] src = new int[sizeX*sizeY];
-        for (int n = 0; n < sizeX*sizeY; n++){
+        int[] src = new int[sizeX * sizeY];
+        for (int n = 0; n < sizeX * sizeY; n++){
             src[n] = n;
         }
         testAllMirrors(src, sizeX, sizeY);
     }
 
-    @Test (expectedExceptions = IllegalArgumentException.class)
+    @Test(expectedExceptions = IllegalArgumentException.class)
     public void testMirrorNullImage() {
         ImageRegionRequestHandler.mirror(null, 4, 4, true, true);
     }
 
-    @Test (expectedExceptions = IllegalArgumentException.class)
+    @Test(expectedExceptions = IllegalArgumentException.class)
     public void testMirrorZeroXImage() {
         int[] src = {1};
         ImageRegionRequestHandler.mirror(src, 0, 4, true, true);
     }
 
-    @Test (expectedExceptions = IllegalArgumentException.class)
+    @Test(expectedExceptions = IllegalArgumentException.class)
     public void testMirrorZeroYImage() {
         int[] src = {1};
         ImageRegionRequestHandler.mirror(src, 4, 0, true, true);
@@ -206,7 +198,7 @@ public class ImageRegionRequestHandlerTest {
 
     @Test
     public void testGetMirroredRegionDef() {
-        RegionDef originalRegion = new RegionDef(1,1,256,256);
+        RegionDef originalRegion = new RegionDef(1, 1, 256, 256);
         RegionDef finalDef = reqHandler.getMirroredRegionDef(
             1024,
             1024,
@@ -224,7 +216,7 @@ public class ImageRegionRequestHandlerTest {
 
     @Test
     public void testGetMirroredRegionDefX() {
-        RegionDef originalRegion = new RegionDef(1,1,256,256);
+        RegionDef originalRegion = new RegionDef(1, 1, 256, 256);
         RegionDef finalDef = reqHandler.getMirroredRegionDef(
             1024,
             1024,
@@ -242,7 +234,7 @@ public class ImageRegionRequestHandlerTest {
 
     @Test
     public void testGetMirroredRegionDefY() {
-        RegionDef originalRegion = new RegionDef(1,1,256,256);
+        RegionDef originalRegion = new RegionDef(1, 1, 256, 256);
         RegionDef finalDef = reqHandler.getMirroredRegionDef(
             1024,
             1024,
@@ -260,7 +252,7 @@ public class ImageRegionRequestHandlerTest {
 
     @Test
     public void testGetMirroredRegionDefXY() {
-        RegionDef originalRegion = new RegionDef(1,1,256,256);
+        RegionDef originalRegion = new RegionDef(1, 1, 256, 256);
         RegionDef finalDef = reqHandler.getMirroredRegionDef(
             1024,
             1024,
@@ -278,7 +270,7 @@ public class ImageRegionRequestHandlerTest {
 
     @Test
     public void testGetMirroredRegionDefXEdge() {
-        RegionDef originalRegion = new RegionDef(0,1,256,256);
+        RegionDef originalRegion = new RegionDef(0, 1, 256, 256);
         RegionDef finalDef = reqHandler.getMirroredRegionDef(
             1023,
             1024,
@@ -296,7 +288,7 @@ public class ImageRegionRequestHandlerTest {
 
     @Test
     public void testGetMirroredRegionDefYEdge() {
-        RegionDef originalRegion = new RegionDef(1,0,256,256);
+        RegionDef originalRegion = new RegionDef(1, 0, 256, 256);
         RegionDef finalDef = reqHandler.getMirroredRegionDef(
             1024,
             1023,
@@ -314,7 +306,7 @@ public class ImageRegionRequestHandlerTest {
 
     @Test
     public void testGetMirroredRegionDefXYEdge() {
-        RegionDef originalRegion = new RegionDef(0,0,256,256);
+        RegionDef originalRegion = new RegionDef(0, 0, 256, 256);
         RegionDef finalDef = reqHandler.getMirroredRegionDef(
             1023,
             1023,
@@ -332,7 +324,7 @@ public class ImageRegionRequestHandlerTest {
 
     @Test
     public void testGetRegionDefCtxTile()
-        throws IllegalArgumentException, ServerError {
+            throws IllegalArgumentException, ServerError {
         int x = 2;
         int y = 2;
         imageRegionCtx.tile = new RegionDef(x, y, 0, 0);
@@ -341,7 +333,8 @@ public class ImageRegionRequestHandlerTest {
         pixels.setSizeY(1024);
         PixelBuffer pixelBuffer = mock(PixelBuffer.class);
         int tileSize = 256;
-        when(pixelBuffer.getTileSize()).thenReturn(new Dimension(tileSize, tileSize));
+        when(pixelBuffer.getTileSize())
+            .thenReturn(new Dimension(tileSize, tileSize));
         RegionDef rdef = reqHandler.getRegionDef(pixels, pixelBuffer);
         Assert.assertEquals(rdef.getX(), x * tileSize);
         Assert.assertEquals(rdef.getY(), y * tileSize);
@@ -351,28 +344,29 @@ public class ImageRegionRequestHandlerTest {
 
     @Test
     public void testGetRegionDefCtxRegion()
-        throws IllegalArgumentException, ServerError {
+            throws IllegalArgumentException, ServerError {
         imageRegionCtx.region = new RegionDef(512, 512, 256, 256);
         Pixels pixels = new Pixels();
         pixels.setSizeX(1024);
         pixels.setSizeY(1024);
         PixelBuffer pixelBuffer = mock(PixelBuffer.class);
-        when(pixelBuffer.getTileSize()).thenReturn(new Dimension(256,256));
+        when(pixelBuffer.getTileSize()).thenReturn(new Dimension(256, 256));
         RegionDef rdef = reqHandler.getRegionDef(pixels, pixelBuffer);
         Assert.assertEquals(rdef.getX(), imageRegionCtx.region.getX());
         Assert.assertEquals(rdef.getY(), imageRegionCtx.region.getY());
         Assert.assertEquals(rdef.getWidth(), imageRegionCtx.region.getWidth());
-        Assert.assertEquals(rdef.getHeight(), imageRegionCtx.region.getHeight());
+        Assert.assertEquals(
+                rdef.getHeight(), imageRegionCtx.region.getHeight());
     }
 
     @Test
     public void testGetRegionDefCtxNoTileOrRegion()
-        throws IllegalArgumentException, ServerError {
+            throws IllegalArgumentException, ServerError {
         Pixels pixels = new Pixels();
         pixels.setSizeX(1024);
         pixels.setSizeY(1024);
         PixelBuffer pixelBuffer = mock(PixelBuffer.class);
-        when(pixelBuffer.getTileSize()).thenReturn(new Dimension(256,256));
+        when(pixelBuffer.getTileSize()).thenReturn(new Dimension(256, 256));
         RegionDef rdef = reqHandler.getRegionDef(pixels, pixelBuffer);
         Assert.assertEquals(rdef.getX(), 0);
         Assert.assertEquals(rdef.getY(), 0);

--- a/src/test/java/com/glencoesoftware/omero/ms/image/region/ImageRegionRequestHandlerTest.java
+++ b/src/test/java/com/glencoesoftware/omero/ms/image/region/ImageRegionRequestHandlerTest.java
@@ -209,7 +209,7 @@ public class ImageRegionRequestHandlerTest {
             .thenReturn(new Dimension(tileSize, tileSize));
         RegionDef rdef = reqHandler.getRegionDef(pixels, pixelBuffer);
         Assert.assertEquals(rdef.getX(), x * tileSize);
-        Assert.assertEquals(rdef.getX(), y * tileSize);
+        Assert.assertEquals(rdef.getY(), y * tileSize);
         Assert.assertEquals(rdef.getWidth(), tileSize);
         Assert.assertEquals(rdef.getHeight(), tileSize);
     }
@@ -225,7 +225,7 @@ public class ImageRegionRequestHandlerTest {
         PixelBuffer pixelBuffer = mock(PixelBuffer.class);
         RegionDef rdef = reqHandler.getRegionDef(pixels, pixelBuffer);
         Assert.assertEquals(rdef.getX(), imageRegionCtx.region.getX());
-        Assert.assertEquals(rdef.getX(), imageRegionCtx.region.getY());
+        Assert.assertEquals(rdef.getY(), imageRegionCtx.region.getY());
         Assert.assertEquals(
                 rdef.getWidth(), imageRegionCtx.region.getWidth());
         Assert.assertEquals(
@@ -243,11 +243,127 @@ public class ImageRegionRequestHandlerTest {
         PixelBuffer pixelBuffer = mock(PixelBuffer.class);
         RegionDef rdef = reqHandler.getRegionDef(pixels, pixelBuffer);
         Assert.assertEquals(rdef.getX(), 0);
-        Assert.assertEquals(rdef.getX(), 0);
+        Assert.assertEquals(rdef.getY(), 0);
         Assert.assertEquals(rdef.getWidth(), 1024);
         Assert.assertEquals(rdef.getHeight(), 1024);
     }
 
+//Test Truncating logic
+    @Test
+    public void testGetRegionDefCtxTileTruncX()
+            throws IllegalArgumentException, ServerError {
+        int x = 1;
+        int y = 0;
+        imageRegionCtx.tile = new RegionDef(x, y, 0, 0);
+        Pixels pixels = new Pixels();
+        pixels.setSizeX(1024);
+        pixels.setSizeY(1024);
+        PixelBuffer pixelBuffer = mock(PixelBuffer.class);
+        int tileSize = 800;
+        when(pixelBuffer.getTileSize())
+            .thenReturn(new Dimension(tileSize, tileSize));
+        RegionDef rdef = reqHandler.getRegionDef(pixels, pixelBuffer);
+        Assert.assertEquals(rdef.getX(), x * tileSize);
+        Assert.assertEquals(rdef.getY(), y * tileSize);
+        Assert.assertEquals(rdef.getWidth(), 1024 - rdef.getX());
+        Assert.assertEquals(rdef.getHeight(), tileSize);
+    }
+
+    @Test
+    public void testGetRegionDefCtxTileTruncY()
+            throws IllegalArgumentException, ServerError {
+        int x = 0;
+        int y = 1;
+        imageRegionCtx.tile = new RegionDef(x, y, 0, 0);
+        Pixels pixels = new Pixels();
+        pixels.setSizeX(1024);
+        pixels.setSizeY(1024);
+        PixelBuffer pixelBuffer = mock(PixelBuffer.class);
+        int tileSize = 800;
+        when(pixelBuffer.getTileSize())
+            .thenReturn(new Dimension(tileSize, tileSize));
+        RegionDef rdef = reqHandler.getRegionDef(pixels, pixelBuffer);
+        Assert.assertEquals(rdef.getX(), x * tileSize);
+        Assert.assertEquals(rdef.getY(), y * tileSize);
+        Assert.assertEquals(rdef.getWidth(), tileSize);
+        Assert.assertEquals(rdef.getHeight(), 1024 - rdef.getY());
+    }
+
+    @Test
+    public void testGetRegionDefCtxTileTruncXY()
+            throws IllegalArgumentException, ServerError {
+        int x = 1;
+        int y = 1;
+        imageRegionCtx.tile = new RegionDef(x, y, 0, 0);
+        Pixels pixels = new Pixels();
+        pixels.setSizeX(1024);
+        pixels.setSizeY(1024);
+        PixelBuffer pixelBuffer = mock(PixelBuffer.class);
+        int tileSize = 800;
+        when(pixelBuffer.getTileSize())
+            .thenReturn(new Dimension(tileSize, tileSize));
+        RegionDef rdef = reqHandler.getRegionDef(pixels, pixelBuffer);
+        Assert.assertEquals(rdef.getX(), x * tileSize);
+        Assert.assertEquals(rdef.getY(), y * tileSize);
+        Assert.assertEquals(rdef.getWidth(), 1024 - rdef.getX());
+        Assert.assertEquals(rdef.getHeight(), 1024 - rdef.getY());
+    }
+
+    @Test
+    public void testGetRegionDefCtxRegionTruncX()
+            throws IllegalArgumentException, ServerError {
+        imageRegionCtx.tile = null;
+        imageRegionCtx.region = new RegionDef(800, 100, 300, 400);
+        Pixels pixels = new Pixels();
+        pixels.setSizeX(1024);
+        pixels.setSizeY(1024);
+        PixelBuffer pixelBuffer = mock(PixelBuffer.class);
+        RegionDef rdef = reqHandler.getRegionDef(pixels, pixelBuffer);
+        Assert.assertEquals(rdef.getX(), imageRegionCtx.region.getX());
+        Assert.assertEquals(rdef.getY(), imageRegionCtx.region.getY());
+        Assert.assertEquals(
+                rdef.getWidth(), 1024 - rdef.getX());
+        Assert.assertEquals(
+                rdef.getHeight(), imageRegionCtx.region.getHeight());
+    }
+
+    @Test
+    public void testGetRegionDefCtxRegionTruncY()
+            throws IllegalArgumentException, ServerError {
+        imageRegionCtx.tile = null;
+        imageRegionCtx.region = new RegionDef(100, 800, 300, 400);
+        Pixels pixels = new Pixels();
+        pixels.setSizeX(1024);
+        pixels.setSizeY(1024);
+        PixelBuffer pixelBuffer = mock(PixelBuffer.class);
+        RegionDef rdef = reqHandler.getRegionDef(pixels, pixelBuffer);
+        Assert.assertEquals(rdef.getX(), imageRegionCtx.region.getX());
+        Assert.assertEquals(rdef.getY(), imageRegionCtx.region.getY());
+        Assert.assertEquals(
+                rdef.getWidth(), imageRegionCtx.region.getWidth());
+        Assert.assertEquals(
+                rdef.getHeight(), 1024 - rdef.getY());
+    }
+
+    @Test
+    public void testGetRegionDefCtxRegionTruncXY()
+            throws IllegalArgumentException, ServerError {
+        imageRegionCtx.tile = null;
+        imageRegionCtx.region = new RegionDef(800, 800, 300, 400);
+        Pixels pixels = new Pixels();
+        pixels.setSizeX(1024);
+        pixels.setSizeY(1024);
+        PixelBuffer pixelBuffer = mock(PixelBuffer.class);
+        RegionDef rdef = reqHandler.getRegionDef(pixels, pixelBuffer);
+        Assert.assertEquals(rdef.getX(), imageRegionCtx.region.getX());
+        Assert.assertEquals(rdef.getY(), imageRegionCtx.region.getY());
+        Assert.assertEquals(
+                rdef.getWidth(), 1024 - rdef.getX());
+        Assert.assertEquals(
+                rdef.getHeight(), 1024 - rdef.getY());
+    }
+
+//Test Mirroring
     @Test
     public void testMirrorRegionDefMirrorX() throws ServerError{
         Pixels pixels = new Pixels();


### PR DESCRIPTION
Adds support for horizontal and vertical flipping/mirroring of rendered regions. This includes required geometric transformations to the tile coordinates such that the caller need only specify the desired flipping orientation and does not have to be concerned with total image geometry or source pixels.

An additional URL parameter `flip` which can take `h` (horizontal), `v` (vertical), or `hv` (horizontal and vertical) flipping requests has been added. This parameter may be applied to all `render_image` and `render_image_region` variants.
