### PR TITLE
Respect tile size parameters

### DIFF
--- a/src/dist/conf/config.yaml
+++ b/src/dist/conf/config.yaml
@@ -22,6 +22,7 @@ omero.server:
     omero.db.pass: "omero"
     # OMERO_HOME/lib/scripts
     omero.script_repo_root: "/opt/omero/lib/scripts"
+    omero.pixeldata.max_tile_length: 1024
 # OMERO.web configuration
 omero.web:
     session_cookie_name: "sessionid"

--- a/src/main/java/com/glencoesoftware/omero/ms/image/region/ImageRegionCtx.java
+++ b/src/main/java/com/glencoesoftware/omero/ms/image/region/ImageRegionCtx.java
@@ -47,8 +47,10 @@ public class ImageRegionCtx extends OmeroRequestCtx {
     public Integer t;
 
     /**
-     * Region descriptor (tile); only X and Y are used at this stage and
-     * represent the <b>tile</b> offset rather than the pixel offset
+     * Region descriptor (tile); only X, Y, and tile width and height are used
+     * at this stage and represent the <b>tile</b> offset, respecting the
+     * provided tile size, rather than the pixel offset; tile width and height
+     * will be 0 if not provided
      */
     public RegionDef tile;
 
@@ -195,6 +197,10 @@ public class ImageRegionCtx extends OmeroRequestCtx {
         tile = new RegionDef();
         tile.setX(Integer.parseInt(tileArray[1]));
         tile.setY(Integer.parseInt(tileArray[2]));
+        if (tileArray.length == 5) {
+            tile.setWidth(Integer.parseInt(tileArray[3]));
+            tile.setHeight(Integer.parseInt(tileArray[4]));
+        }
         resolution = Integer.parseInt(tileArray[0]);
     }
 

--- a/src/main/java/com/glencoesoftware/omero/ms/image/region/ImageRegionMicroserviceVerticle.java
+++ b/src/main/java/com/glencoesoftware/omero/ms/image/region/ImageRegionMicroserviceVerticle.java
@@ -48,6 +48,7 @@ import io.vertx.core.json.JsonArray;
 import io.vertx.ext.web.Router;
 import io.vertx.ext.web.RoutingContext;
 import io.vertx.ext.web.handler.CookieHandler;
+import ome.system.PreferenceContext;
 import omero.model.Image;
 
 /**
@@ -63,6 +64,9 @@ public class ImageRegionMicroserviceVerticle extends AbstractVerticle {
 
     /** OMERO server Spring application context. */
     private ApplicationContext context;
+
+    /** OMERO server wide preference context. */
+    private PreferenceContext preferences;
 
     /** OMERO.web session store */
     private OmeroWebSessionStore sessionStore;
@@ -117,6 +121,8 @@ public class ImageRegionMicroserviceVerticle extends AbstractVerticle {
                 "classpath:ome/config.xml",
                 "classpath:ome/services/datalayer.xml",
                 "classpath*:beanRefContext.xml");
+        preferences =
+                (PreferenceContext) this.context.getBean("preferenceContext");
 
         // Deploy our dependency verticles
         JsonObject omero = config.getJsonObject("omero");
@@ -234,13 +240,21 @@ public class ImageRegionMicroserviceVerticle extends AbstractVerticle {
         String version = Optional.ofNullable(
             this.getClass().getPackage().getImplementationVersion()
         ).orElse("development");
+        int maxTileLength = Integer.parseInt(
+                Optional.ofNullable(
+                    preferences.getProperty("omero.pixeldata.max_tile_length")
+                ).orElse("1024").toLowerCase()
+            );
         JsonObject resData = new JsonObject()
                 .put("provider", "ImageRegionMicroservice")
                 .put("version", version)
                 .put("features", new JsonArray()
-                                     .add("flip")
-                                     .add("mask-color")
-                                     .add("png-tiles"));
+                                 .add("flip")
+                                 .add("mask-color")
+                                 .add("png-tiles"))
+                .put("options", new JsonArray()
+                                .add(new JsonObject()
+                                    .put("maxTileLength", maxTileLength)));
         event.response()
             .putHeader("content-type", "application/json")
             .end(resData.encodePrettily());

--- a/src/main/java/com/glencoesoftware/omero/ms/image/region/ImageRegionMicroserviceVerticle.java
+++ b/src/main/java/com/glencoesoftware/omero/ms/image/region/ImageRegionMicroserviceVerticle.java
@@ -252,9 +252,8 @@ public class ImageRegionMicroserviceVerticle extends AbstractVerticle {
                                  .add("flip")
                                  .add("mask-color")
                                  .add("png-tiles"))
-                .put("options", new JsonArray()
-                                .add(new JsonObject()
-                                    .put("maxTileLength", maxTileLength)));
+                .put("options",new JsonObject()
+                               .put("maxTileLength", maxTileLength));
         event.response()
             .putHeader("content-type", "application/json")
             .end(resData.encodePrettily());

--- a/src/main/java/com/glencoesoftware/omero/ms/image/region/ImageRegionRequestHandler.java
+++ b/src/main/java/com/glencoesoftware/omero/ms/image/region/ImageRegionRequestHandler.java
@@ -618,18 +618,18 @@ public class ImageRegionRequestHandler {
         int sizeX = resolutionLevels.get(resolution).get(0);
         int sizeY = resolutionLevels.get(resolution).get(1);
         RegionDef regionDef = new RegionDef();
-        Dimension defaultTileSize = pixelBuffer.getTileSize();
+        Dimension imageTileSize = pixelBuffer.getTileSize();
         if (imageRegionCtx.tile != null) {
             int tileSizeX = imageRegionCtx.tile.getWidth();
             int tileSizeY = imageRegionCtx.tile.getHeight();
             if (tileSizeX == 0) {
-                tileSizeX = (int) defaultTileSize.getWidth();
+                tileSizeX = (int) imageTileSize.getWidth();
             }
             if (tileSizeX > maxTileLength) {
                 tileSizeX = maxTileLength;
             }
             if (tileSizeY == 0) {
-                tileSizeY = (int) defaultTileSize.getHeight();
+                tileSizeY = (int) imageTileSize.getHeight();
             }
             if (tileSizeY > maxTileLength) {
                 tileSizeY = maxTileLength;

--- a/src/main/java/com/glencoesoftware/omero/ms/image/region/ImageRegionVerticle.java
+++ b/src/main/java/com/glencoesoftware/omero/ms/image/region/ImageRegionVerticle.java
@@ -22,6 +22,7 @@ import java.io.File;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
+import java.util.Optional;
 import java.util.stream.Collectors;
 
 import org.perf4j.StopWatch;
@@ -91,6 +92,9 @@ public class ImageRegionVerticle extends AbstractVerticle {
     /** Available rendering models */
     private List<RenderingModel> renderingModels;
 
+    /** Configured maximum size size in either dimension */
+    private final int maxTileLength;
+
     /**
      * Default constructor.
      * @param host OMERO server host.
@@ -107,6 +111,11 @@ public class ImageRegionVerticle extends AbstractVerticle {
         scriptRepoRoot = preferences.getProperty("omero.script_repo_root");
         lutType = (ScriptFileType) context.getBean("LUTScripts");
         lutProvider = new LutProviderImpl(new File(scriptRepoRoot), lutType);
+        maxTileLength = Integer.parseInt(
+            Optional.ofNullable(
+                preferences.getProperty("omero.pixeldata.max_tile_length")
+            ).orElse("1024").toLowerCase()
+        );
     }
 
     /* (non-Javadoc)
@@ -163,7 +172,8 @@ public class ImageRegionVerticle extends AbstractVerticle {
                             imageRegionCtx, context, families,
                             renderingModels, lutProvider,
                             pixelsService,
-                            compressionService)::renderImageRegion);
+                            compressionService,
+                            maxTileLength)::renderImageRegion);
             if (imageRegion == null) {
                 message.fail(
                         404, "Cannot find Image:" + imageRegionCtx.imageId);

--- a/src/test/java/com/glencoesoftware/omero/ms/image/region/ImageRegionCtxTest.java
+++ b/src/test/java/com/glencoesoftware/omero/ms/image/region/ImageRegionCtxTest.java
@@ -45,7 +45,7 @@ public class ImageRegionCtxTest {
     final private int tileX = 0;
     final private int tileY = 1;
     final private String tile = String.format(
-            "%d,%d,%d,1024,1024", resolution, tileX, tileY);
+            "%d,%d,%d,1024,2048", resolution, tileX, tileY);
     // region
     final private int regionX = 1;
     final private int regionY = 2;
@@ -189,6 +189,28 @@ public class ImageRegionCtxTest {
     }
 
     @Test
+    public void testTileShortParameters()
+            throws JsonParseException, JsonMappingException, IOException {
+        params.remove("region");
+        params.add("tile", String.format("%d,%d,%d", resolution, tileX, tileY));
+
+        ImageRegionCtx imageCtx = new ImageRegionCtx(params, "");
+        String data = Json.encode(imageCtx);
+        ObjectMapper mapper = new ObjectMapper();
+        ImageRegionCtx imageCtxDecoded = mapper.readValue(
+                data, ImageRegionCtx.class);
+
+        Assert.assertNull(imageCtxDecoded.region);
+        Assert.assertNotNull(imageCtxDecoded.tile);
+        Assert.assertEquals(imageCtxDecoded.tile.getX(), tileX);
+        Assert.assertEquals(imageCtxDecoded.tile.getY(), tileY);
+        Assert.assertEquals(imageCtxDecoded.tile.getWidth(), 0);
+        Assert.assertEquals(imageCtxDecoded.tile.getHeight(), 0);
+        Assert.assertEquals((int) imageCtxDecoded.resolution, resolution);
+        assertChannelInfo(imageCtxDecoded);
+    }
+
+    @Test
     public void testTileParameters()
             throws JsonParseException, JsonMappingException, IOException {
         params.remove("region");
@@ -204,8 +226,8 @@ public class ImageRegionCtxTest {
         Assert.assertNotNull(imageCtxDecoded.tile);
         Assert.assertEquals(imageCtxDecoded.tile.getX(), tileX);
         Assert.assertEquals(imageCtxDecoded.tile.getY(), tileY);
-        Assert.assertEquals(imageCtxDecoded.tile.getWidth(), 0);
-        Assert.assertEquals(imageCtxDecoded.tile.getHeight(), 0);
+        Assert.assertEquals(imageCtxDecoded.tile.getWidth(), 1024);
+        Assert.assertEquals(imageCtxDecoded.tile.getHeight(), 2048);
         Assert.assertEquals((int) imageCtxDecoded.resolution, resolution);
         assertChannelInfo(imageCtxDecoded);
     }

--- a/src/test/java/com/glencoesoftware/omero/ms/image/region/ImageRegionCtxTest.java
+++ b/src/test/java/com/glencoesoftware/omero/ms/image/region/ImageRegionCtxTest.java
@@ -115,77 +115,77 @@ public class ImageRegionCtxTest {
     public void testMissingImageId()
             throws JsonParseException, JsonMappingException, IOException {
         params.remove("imageId");
-        ImageRegionCtx imageCtx = new ImageRegionCtx(params, "");
+        new ImageRegionCtx(params, "");
     }
 
     @Test(expectedExceptions = IllegalArgumentException.class)
     public void testImageIdFormat()
             throws JsonParseException, JsonMappingException, IOException {
         params.add("imageId", "abc");
-        ImageRegionCtx imageCtx = new ImageRegionCtx(params, "");
+        new ImageRegionCtx(params, "");
     }
 
     @Test(expectedExceptions = IllegalArgumentException.class)
     public void testMissingTheZ()
             throws JsonParseException, JsonMappingException, IOException {
         params.remove("theZ");
-        ImageRegionCtx imageCtx = new ImageRegionCtx(params, "");
+        new ImageRegionCtx(params, "");
     }
 
     @Test(expectedExceptions = IllegalArgumentException.class)
     public void testTheZFormat()
             throws JsonParseException, JsonMappingException, IOException {
         params.add("theZ", "abc");
-        ImageRegionCtx imageCtx = new ImageRegionCtx(params, "");
+        new ImageRegionCtx(params, "");
     }
 
     @Test(expectedExceptions = IllegalArgumentException.class)
     public void testMissingTheT()
             throws JsonParseException, JsonMappingException, IOException {
         params.remove("theT");
-        ImageRegionCtx imageCtx = new ImageRegionCtx(params, "");
+        new ImageRegionCtx(params, "");
     }
 
     @Test(expectedExceptions = IllegalArgumentException.class)
     public void testTheTFormat()
             throws JsonParseException, JsonMappingException, IOException {
         params.add("theT", "abc");
-        ImageRegionCtx imageCtx = new ImageRegionCtx(params, "");
+        new ImageRegionCtx(params, "");
     }
 
     @Test(expectedExceptions = IllegalArgumentException.class)
     public void testRegionFormat()
             throws JsonParseException, JsonMappingException, IOException {
         params.add("region", "1,2,3,abc");
-        ImageRegionCtx imageCtx = new ImageRegionCtx(params, "");
+        new ImageRegionCtx(params, "");
     }
 
     @Test(expectedExceptions = IllegalArgumentException.class)
     public void testChannelFormat()
             throws JsonParseException, JsonMappingException, IOException {
         params.add("c", "-1|0:65535$0000FF,a|1755:51199$00FF00,3|3218:26623$FF0000");
-        ImageRegionCtx imageCtx = new ImageRegionCtx(params, "");
+        new ImageRegionCtx(params, "");
     }
 
     @Test(expectedExceptions = IllegalArgumentException.class)
     public void testChannelFormatActive()
             throws JsonParseException, JsonMappingException, IOException {
         params.add("c", "-1|0:65535$0000FF,a|1755:51199$00FF00,3|3218:26623$FF0000");
-        ImageRegionCtx imageCtx = new ImageRegionCtx(params, "");
+        new ImageRegionCtx(params, "");
     }
 
     @Test(expectedExceptions = IllegalArgumentException.class)
     public void testChannelFormatRange()
             throws JsonParseException, JsonMappingException, IOException {
         params.add("c", "-1|0:65535$0000FF,1|abc:51199$00FF00,3|3218:26623$FF0000");
-        ImageRegionCtx imageCtx = new ImageRegionCtx(params, "");
+        new ImageRegionCtx(params, "");
     }
 
     @Test(expectedExceptions = IllegalArgumentException.class)
     public void testQualityFormat()
             throws JsonParseException, JsonMappingException, IOException {
         params.add("q", "abc");
-        ImageRegionCtx imageCtx = new ImageRegionCtx(params, "");
+        new ImageRegionCtx(params, "");
     }
 
     @Test

--- a/src/test/java/com/glencoesoftware/omero/ms/image/region/ImageRegionRequestHandlerTest.java
+++ b/src/test/java/com/glencoesoftware/omero/ms/image/region/ImageRegionRequestHandlerTest.java
@@ -31,7 +31,6 @@ import org.testng.annotations.Test;
 
 import io.vertx.core.MultiMap;
 import io.vertx.core.http.CaseInsensitiveHeaders;
-import ome.model.core.Pixels;
 import ome.io.nio.PixelBuffer;
 import ome.model.enums.Family;
 import ome.model.enums.RenderingModel;
@@ -62,7 +61,8 @@ public class ImageRegionRequestHandlerTest {
                 new ArrayList<RenderingModel>(),
                 null, //LutProvider lutProvider,
                 null, //LocalCompress compSrv,
-                null); //PixelsService pixService);
+                null, //PixelsService pixService,
+                1024); //maxTileLength);
     }
 
     private void testFlip(
@@ -217,6 +217,26 @@ public class ImageRegionRequestHandlerTest {
         Assert.assertEquals(rdef.getY(), y * tileSize);
         Assert.assertEquals(rdef.getWidth(), tileSize);
         Assert.assertEquals(rdef.getHeight(), tileSize);
+    }
+
+    @Test
+    public void testGetRegionDefCtxTileWithWidthAndHeight()
+            throws IllegalArgumentException, ServerError {
+        int x = 2;
+        int y = 2;
+        imageRegionCtx.tile = new RegionDef(x, y, 64, 128);
+        List<List<Integer>> resolutionLevels = new ArrayList<List<Integer>>();
+        List<Integer> resolutionLevel =
+                Arrays.asList(new Integer[] { 1024, 1024 });
+        resolutionLevels.add(resolutionLevel);
+        PixelBuffer pixelBuffer = mock(PixelBuffer.class);
+        when(pixelBuffer.getTileSize())
+            .thenReturn(new Dimension(64, 128));
+        RegionDef rdef = reqHandler.getRegionDef(resolutionLevels, pixelBuffer);
+        Assert.assertEquals(rdef.getX(), x * 64);
+        Assert.assertEquals(rdef.getY(), y * 128);
+        Assert.assertEquals(rdef.getWidth(), 64);
+        Assert.assertEquals(rdef.getHeight(), 128);
     }
 
     @Test


### PR DESCRIPTION
In openmicroscopy/openmicroscopy#5542 (included in OMERO 5.4.4) the OMERO.web implementation was changed to respect tile size parameters provided by the client. This PR brings the microservice in line with that upstream decision.

/cc @kkoz 