### PR TITLE
Upgrade logging and remove metrics

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -71,7 +71,7 @@ configurations.all {
 }
 
 dependencies {
-    compile 'ch.qos.logback:logback-classic:1.1.7'
+    compile 'ch.qos.logback:logback-classic:1.2.3'
     compile ('com.glencoesoftware.omero:omero-ms-core:0.4.1') {
         exclude group: 'org.testng', module: 'testng'
     }

--- a/build.gradle
+++ b/build.gradle
@@ -5,7 +5,7 @@ plugins {
 }
 
 group = 'com.glencoesoftware.omero'
-version = '0.4.4'
+version = '0.4.5-SNAPSHOT'
 
 mainClassName = 'io.vertx.core.Starter'
 

--- a/build.gradle
+++ b/build.gradle
@@ -35,6 +35,7 @@ configurations.all {
     exclude group: 'batik'
     exclude group: 'cglib'
     exclude group: 'checkstyle'
+    exclude group: 'com.codahale.metrics'
     exclude group: 'com.jamonapi'
     exclude group: 'com.mortennobel'
     exclude group: 'com.zeroc', module: 'freeze'

--- a/src/main/resources/beanRefContext.xml
+++ b/src/main/resources/beanRefContext.xml
@@ -33,18 +33,6 @@
 
   <alias name="${omero.pixeldata.tile_sizes_bean}" alias="tileSizes"/>
 
-  <alias name="${omero.metrics.bean}" alias="metrics"/>
-
-  <bean id="defaultMetrics" class="ome.system.metrics.DefaultMetrics">
-    <property name="slf4jMinutes" value="${omero.metrics.slf4j_minutes}"/>
-    <property name="beginsWith">
-        <list><value>ome.services.pixeldata</value></list>
-    </property>
-    <property name="graphiteAddress" value="${omero.metrics.graphite}"/>
-  </bean>
-
-  <bean id="nullMetrics" class="ome.system.metrics.NullMetrics"/>
-
   <alias name="internal-ome.api.ICompress"
          alias="internal-ome.api.LocalCompress"/>
   <bean id="internal-ome.api.ICompress"


### PR DESCRIPTION
We've had full microservice hangs where `jstack` stacktraces that imply issues with the metrics library. There are also various bugs and performance improvements that have been made since the 1.1.1 logback version we were previously using.

I have chosen to completely remove the metrics library here until we give some thought to how we would expose it to users and whether or not to just introduce a full tracing library instead. At best it is eating up heap space now and at worst causing the microservice to completely deadlock under high load.

On the `upgrade-logging-and-metrics-dependencies` branch on my fork of this repository there is a commit that upgrades the dropwizard metrics library to 3.2.6. Seems to work and we might do that on the OMERO side in the short/medium term.

/cc @joshmoore 