### PR TITLE
Small changes to memo regeneration

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -85,7 +85,7 @@ dependencies {
     compile 'org.springframework:spring-context-support:4.3.14.RELEASE'
     compile 'io.prometheus.jmx:collector:0.12.0'
     compile 'io.prometheus:simpleclient_hotspot:0.8.0'
-    compile 'info.picocli:picocli:3.9.3'
+    compile 'info.picocli:picocli:4.1.4'
     compile 'com.univocity:univocity-parsers:2.8.3'
     testCompile 'org.testng:testng:6.10'
     testCompile 'org.mockito:mockito-core:2.+'

--- a/src/main/java/com/glencoesoftware/omero/ms/image/region/MemoRegenerator.java
+++ b/src/main/java/com/glencoesoftware/omero/ms/image/region/MemoRegenerator.java
@@ -177,7 +177,7 @@ public class MemoRegenerator implements Callable<Void> {
             try {
                 Pixels pixels = pixelsFromRow(row);
                 pixelsService.getPixelBuffer(pixels, false);
-            } catch(Exception e) {
+            } catch (Exception e) {
                 log.error("Caught exception processing row {}", i, e);
             } finally {
                 i++;

--- a/src/main/java/com/glencoesoftware/omero/ms/image/region/MemoRegenerator.java
+++ b/src/main/java/com/glencoesoftware/omero/ms/image/region/MemoRegenerator.java
@@ -45,17 +45,12 @@ import picocli.CommandLine.Command;
 import picocli.CommandLine.Option;
 import picocli.CommandLine.Parameters;
 
-@Command(name="memoregenerator",
-    description = "Regenerates Bio Formats memo files")
+@Command(name="memoregenerator", mixinStandardHelpOptions=true,
+    description = "Regenerates Bio-Formats memo files")
 public class MemoRegenerator implements Callable<Void> {
 
     private static final Logger log =
             LoggerFactory.getLogger(MemoRegenerator.class);
-
-    @Option(names = {"-h", "--help"},
-            usageHelp = true,
-            description = "display this help message")
-    boolean usageHelpRequested;
 
     @Option(
         names = "--inplace",

--- a/src/main/java/com/glencoesoftware/omero/ms/image/region/MemoRegenerator.java
+++ b/src/main/java/com/glencoesoftware/omero/ms/image/region/MemoRegenerator.java
@@ -206,7 +206,7 @@ public class MemoRegenerator implements Callable<Void> {
     }
 
     public static void main(String[] args) {
-        CommandLine.call(new MemoRegenerator(), args);
+        new CommandLine(new MemoRegenerator()).execute(args);
     }
 
 }

--- a/src/main/java/com/glencoesoftware/omero/ms/image/region/MemoRegenerator.java
+++ b/src/main/java/com/glencoesoftware/omero/ms/image/region/MemoRegenerator.java
@@ -173,12 +173,12 @@ public class MemoRegenerator implements Callable<Void> {
         int total = rowProcessor.getRows().size();
         int i = 1;
         for (Object[] row : rowProcessor.getRows()) {
-            log.info(String.format("Processing row %d of %d", i, total));
+            log.info("Processing row {} of {}", i, total);
             try {
                 Pixels pixels = pixelsFromRow(row);
                 pixelsService.getPixelBuffer(pixels, false);
             } catch(Exception e) {
-                log.error(String.format("Caught exception processing row %d", i), e);
+                log.error("Caught exception processing row {}", i, e);
             } finally {
                 i++;
             }


### PR DESCRIPTION
- Should not complain about missing parameter when -h is used
- <main class> is confusing in the help text. Should just say 'memoregenerator'
- `--cache-dir` is required unless `--inplace` is specified
- Errors are logged but do not cause complete failure
- Row number/total is logged to track progress