### PR TITLE
Memoizer script fixes

### DIFF
--- a/src/dist/memofile-regen-status.sh
+++ b/src/dist/memofile-regen-status.sh
@@ -97,7 +97,8 @@ REGEN_RUNNING=$(ps -Fw --no-headers ${PARENT_PID})
 
 if [ -n "${REGEN_RUNNING}" ]; then
   echo "regen script running (${PARENT_PID})"
-  PARALLEL_PID=$(pgrep -P ${PARENT_PID})
+  TIME_PID=$(pgrep -P ${PARENT_PID} time)
+  PARALLEL_PID=$(pgrep -P ${TIME_PID} perl)
   if [ -n "${PARALLEL_PID}" ]; then
     RUNNING_MEMOIZERS=$(pgrep -P ${PARALLEL_PID}| wc -l)
     MEMOIZER_PIDS=$(pgrep -d' ' -P ${PARALLEL_PID})

--- a/src/dist/regen-memo-files.sh
+++ b/src/dist/regen-memo-files.sh
@@ -46,7 +46,7 @@ set -x
   export JAVA_OPTS="-XX:+HeapDumpOnOutOfMemoryError -XX:HeapDumpPath=rslt.${DATESTR} -Xmx2g -Dlogback.configurationFile=${MEMOIZER_HOME}/logback-memoizer.xml -Dprocessname=memoizer"
   CENTOS_VERSION=$(cat /etc/centos-release |cut -f 3 -d' '|cut -d. -f 1)
   cd rslt.${DATESTR}
-  split -l ${BATCH_SIZE} ${FULL_CSV} -d input.
+  split -a 3 -l ${BATCH_SIZE} ${FULL_CSV} -d input.
   PARALLEL_OPTS="error"
   if [ "${CENTOS_VERSION}" = "6" ]; then
     PARALLEL_OPTS="--halt 2 --gnu --eta --jobs ${JOBS} --joblog parallel-${JOBS}cpus.log --files --use-cpus-instead-of-cores --result . ${DRYRUN}"


### PR DESCRIPTION
Found a few minor bugs when we ran it on hms.

The move to using /usr/bin/time instead of the shell builtin time means theres an extra pid in the tree.