### PR TITLE
fix math oversight in counting total processed files

### DIFF
--- a/src/dist/memofile-regen-status.sh
+++ b/src/dist/memofile-regen-status.sh
@@ -81,7 +81,7 @@ STDERR_FILES=$( find ${PRSLTDIR} -type f -and -name stderr -and -size +0 -print 
 OK_IMAGES=$( grep 'ok: ' ${STDOUT_FILES} |wc -l )
 FAIL_IMAGES=$( grep 'fail: ' ${STDOUT_FILES} | wc -l )
 SKIP_IMAGES=$( grep 'skip: ' ${STDOUT_FILES} | wc -l )
-PROCESSED_IMAGES=$(( $OK_IMAGES + $FAIL_IMAGES ))
+PROCESSED_IMAGES=$(( $OK_IMAGES + $FAIL_IMAGES + $SKIP_IMAGES ))
 TOTAL_IMAGES=$( wc -l ${IMAGE_LIST} |awk '{ print $1 }')
 
 echo -e "Output Files / Total Images"


### PR DESCRIPTION
@chris-allan you were right, when we added skip files they weren't being counted as 'processed' so the count was always off by the number of skipped files.  HMS didn't have very many so it wasn't so obvious the math was wrong.