### PR TITLE
Handle unexpected failure codes

### DIFF
--- a/src/main/java/com/glencoesoftware/omero/ms/image/region/ImageRegionMicroserviceVerticle.java
+++ b/src/main/java/com/glencoesoftware/omero/ms/image/region/ImageRegionMicroserviceVerticle.java
@@ -384,7 +384,9 @@ public class ImageRegionMicroserviceVerticle extends AbstractVerticle {
                 statusCode = ((ReplyException) t).failureCode();
             }
             if (statusCode < 200 || statusCode > 599) {
-                log.error("Unexpected failureCode {} resetting to 500", t);
+                log.error(
+                    "Unexpected failureCode {} resetting to 500",
+                    statusCode, t);
                 statusCode = 500;
             }
             response.setStatusCode(statusCode);

--- a/src/main/java/com/glencoesoftware/omero/ms/image/region/ImageRegionMicroserviceVerticle.java
+++ b/src/main/java/com/glencoesoftware/omero/ms/image/region/ImageRegionMicroserviceVerticle.java
@@ -484,10 +484,9 @@ public class ImageRegionMicroserviceVerticle extends AbstractVerticle {
                 if(!cacheControlHeader.equals("")) {
                     response.headers().set("Cache-Control", cacheControlHeader);
                 }
-                if (!response.closed()) {
-                    response.end(Buffer.buffer(imageRegion));
-                }
+                response.write(Buffer.buffer(imageRegion));
             } finally {
+                response.end();
                 log.debug("Response ended");
             }
         });

--- a/src/main/java/com/glencoesoftware/omero/ms/image/region/ImageRegionMicroserviceVerticle.java
+++ b/src/main/java/com/glencoesoftware/omero/ms/image/region/ImageRegionMicroserviceVerticle.java
@@ -481,12 +481,12 @@ public class ImageRegionMicroserviceVerticle extends AbstractVerticle {
                 response.headers().set(
                         "Content-Length",
                         String.valueOf(imageRegion.length));
-                if(!cacheControlHeader.equals("")) {
+                if (!cacheControlHeader.equals("")) {
                     response.headers().set("Cache-Control", cacheControlHeader);
                 }
                 response.write(Buffer.buffer(imageRegion));
             } finally {
-                if(!response.closed()) {
+                if (!response.closed()) {
                     response.end();
                 }
                 log.debug("Response ended");
@@ -524,7 +524,7 @@ public class ImageRegionMicroserviceVerticle extends AbstractVerticle {
                         String.valueOf(shapeMask.length));
                 response.write(Buffer.buffer(shapeMask));
             } finally {
-                if(!response.closed()) {
+                if (!response.closed()) {
                     response.end();
                 }
                 log.debug("Response ended");

--- a/src/main/java/com/glencoesoftware/omero/ms/image/region/ImageRegionMicroserviceVerticle.java
+++ b/src/main/java/com/glencoesoftware/omero/ms/image/region/ImageRegionMicroserviceVerticle.java
@@ -442,7 +442,9 @@ public class ImageRegionMicroserviceVerticle extends AbstractVerticle {
                     request.params(), event.get("omero.session_key"));
         } catch (IllegalArgumentException e) {
             HttpServerResponse response = event.response();
-            response.setStatusCode(400).end(e.getMessage());
+            if (!response.closed()) {
+                response.setStatusCode(400).end(e.getMessage());
+            }
             return;
         }
         int activeChannelCount = 0;
@@ -451,9 +453,11 @@ public class ImageRegionMicroserviceVerticle extends AbstractVerticle {
         }
         if (activeChannelCount > MAX_ACTIVE_CHANNELS) {
             HttpServerResponse response = event.response();
-            response.setStatusCode(400).end(String.format(
-                "Too many active channels. Cannot process more than %d per request",
-                MAX_ACTIVE_CHANNELS));
+            if (!response.closed()) {
+                response.setStatusCode(400).end(String.format(
+                    "Too many active channels. Cannot process more than " +
+                    "%d per request", MAX_ACTIVE_CHANNELS));
+            }
             return;
         }
         imageRegionCtx.injectCurrentTraceContext();

--- a/src/main/java/com/glencoesoftware/omero/ms/image/region/ImageRegionMicroserviceVerticle.java
+++ b/src/main/java/com/glencoesoftware/omero/ms/image/region/ImageRegionMicroserviceVerticle.java
@@ -486,7 +486,9 @@ public class ImageRegionMicroserviceVerticle extends AbstractVerticle {
                 }
                 response.write(Buffer.buffer(imageRegion));
             } finally {
-                response.end();
+                if(!response.closed()) {
+                    response.end();
+                }
                 log.debug("Response ended");
             }
         });
@@ -522,7 +524,9 @@ public class ImageRegionMicroserviceVerticle extends AbstractVerticle {
                         String.valueOf(shapeMask.length));
                 response.write(Buffer.buffer(shapeMask));
             } finally {
-                response.end();
+                if(!response.closed()) {
+                    response.end();
+                }
                 log.debug("Response ended");
             }
         });


### PR DESCRIPTION
Sometimes we seem to be getting failure codes of -1 which results in
Netty throwing an IllegalArgumentException as -1 is not a valid HTTP
status code.  This handles those scenarios, by setting the status code
to 500, and logs the fault exception at ERROR.

If this works well we'll need it on ms-thumbnail and ms-pixel-buffer
as well.

/cc @stick 