### PR TITLE
Fix directory file handle leak

### DIFF
--- a/src/main/java/com/glencoesoftware/omero/ms/image/region/OmeroZarrUtils.java
+++ b/src/main/java/com/glencoesoftware/omero/ms/image/region/OmeroZarrUtils.java
@@ -495,9 +495,8 @@ public class OmeroZarrUtils {
                     .resolve(Long.toString(filesetId) + ZARR_EXTN)
                     .resolve(Integer.toString(series));
             int count = 0;
-            try {
-                DirectoryStream<Path> stream =
-                        Files.newDirectoryStream(zarrSeriesPath);
+            try (DirectoryStream<Path> stream =
+                        Files.newDirectoryStream(zarrSeriesPath)) {
                 for (Path entry : stream) {
                     try {
                         Integer.parseInt(entry.getFileName().toString());


### PR DESCRIPTION
If we don't close early we'll have to wait for GC for the filehandles opened by the directory stream to be released. This can result in the process running out of available filehandles when NGFF data for a given image is missing or incomplete.

/cc @erindiel 