### PR TITLE
Fix Plate based OME-NGFF data

### DIFF
--- a/src/main/java/com/glencoesoftware/omero/ms/image/region/ImageRegionRequestHandler.java
+++ b/src/main/java/com/glencoesoftware/omero/ms/image/region/ImageRegionRequestHandler.java
@@ -56,6 +56,7 @@ import ome.model.enums.RenderingModel;
 import ome.model.fs.Fileset;
 import ome.util.ImageUtil;
 import omeis.providers.re.Renderer;
+import omeis.providers.re.RenderingStats;
 import omeis.providers.re.data.PlaneDef;
 import omeis.providers.re.data.RegionDef;
 import omeis.providers.re.lut.LutProvider;
@@ -497,9 +498,10 @@ public class ImageRegionRequestHandler {
         } finally {
             try {
                 if (renderer != null) {
-                    span.tag(
-                            "omero.rendering_stats",
-                            renderer.getStats().getStats());
+                    RenderingStats stats = renderer.getStats();
+                    if (stats != null) {
+                        span.tag("omero.rendering_stats", stats.getStats());
+                    }
                 }
             } finally {
                 span.finish();

--- a/src/main/java/com/glencoesoftware/omero/ms/image/region/ImageRegionRequestHandler.java
+++ b/src/main/java/com/glencoesoftware/omero/ms/image/region/ImageRegionRequestHandler.java
@@ -327,7 +327,7 @@ public class ImageRegionRequestHandler {
      * @return BufferedImage of the data
      * @throws IOException
      */
-    private BufferedImage getBufferedImage(Array array) throws IOException {
+    protected BufferedImage getBufferedImage(Array array) throws IOException {
         Integer sizeY = array.getShape()[0];
         Integer sizeX = array.getShape()[1];
         int[] buf = (int[]) array.getStorage();

--- a/src/main/java/com/glencoesoftware/omero/ms/image/region/ImageRegionRequestHandler.java
+++ b/src/main/java/com/glencoesoftware/omero/ms/image/region/ImageRegionRequestHandler.java
@@ -53,7 +53,6 @@ import ome.model.display.ChannelBinding;
 import ome.model.display.RenderingDef;
 import ome.model.enums.Family;
 import ome.model.enums.RenderingModel;
-import ome.model.fs.Fileset;
 import ome.util.ImageUtil;
 import omeis.providers.re.Renderer;
 import omeis.providers.re.RenderingStats;
@@ -186,7 +185,9 @@ public class ImageRegionRequestHandler {
                     ((omero.RLong) pixelsIdAndSeries.get(0)).getValue();
             span.tag("omero.pixels_id", Long.toString(pixelsId));
             // Query pulled from ome.logic.PixelsImpl and expanded to include
-            // our required Image / Plate metadata
+            // our required Image / Plate metadata; loading both sides of the
+            // Image <--> WellSample <--> Well collection so that we can
+            // resolve our field index.
             ParametersI params = new ParametersI();
             params.addId(pixelsId);
             pixels = (Pixels) mapper.reverse(
@@ -194,7 +195,8 @@ public class ImageRegionRequestHandler {
                         "select p from Pixels as p "
                         + "join fetch p.image as i "
                         + "left outer join fetch i.wellSamples as ws "
-                        + "left outer join fetch ws.well "
+                        + "left outer join fetch ws.well as w "
+                        + "left outer join fetch w.wellSamples "
                         + "join fetch p.pixelsType "
                         + "join fetch p.channels as c "
                         + "join fetch c.logicalChannel as lc "

--- a/src/main/java/com/glencoesoftware/omero/ms/image/region/PixelsService.java
+++ b/src/main/java/com/glencoesoftware/omero/ms/image/region/PixelsService.java
@@ -173,15 +173,12 @@ public class PixelsService extends ome.io.nio.PixelsService {
                     filesetId, well.getRow(), well.getColumn(), field);
         }
         return String.format(
-                "%d.zarr/%d/labels/%s", filesetId, image.getSeries());
+                "%d.zarr/%d", filesetId, image.getSeries());
     }
 
     private String getLabelImageSubPath(Pixels pixels, String uuid) {
         return String.format(
-                "%s/labels/%s",
-                getImageSubPath(pixels),
-                pixels.getImage().getSeries(),
-                uuid);
+                "%s/labels/%s", getImageSubPath(pixels), uuid);
     }
 
     /**

--- a/src/main/java/com/glencoesoftware/omero/ms/image/region/ThumbnailCtx.java
+++ b/src/main/java/com/glencoesoftware/omero/ms/image/region/ThumbnailCtx.java
@@ -86,21 +86,19 @@ public class ThumbnailCtx extends ImageRegionCtx {
     public void setResolutionLevel(
             Renderer renderer, PixelBuffer pixelBuffer) {
         List<List<Integer>> rds = pixelBuffer.getResolutionDescriptions();
-        int resolutionLevelCount = rds.size();
 
-        int resolutionLevel = 0;
-        for (; resolutionLevel < rds.size(); resolutionLevel++) {
+        int resolutionLevel = rds.size() - 1;
+        for (; resolutionLevel >= 0; resolutionLevel--) {
             if (rds.get(resolutionLevel).get(0) < longestSide
                 && rds.get(resolutionLevel).get(1) < longestSide) {
                 break;
             }
         }
-        resolutionLevel -= 1;
+        resolutionLevel += 1;
         if (resolutionLevel < 0) {
             throw new IllegalArgumentException(
                     "longestSide exceeds image size");
         }
-        resolutionLevel = resolutionLevelCount - resolutionLevel - 1;
         log.debug("Selected resolution level: {}", resolutionLevel);
         renderer.setResolutionLevel(resolutionLevel);
     }

--- a/src/main/java/com/glencoesoftware/omero/ms/image/region/ThumbnailCtx.java
+++ b/src/main/java/com/glencoesoftware/omero/ms/image/region/ThumbnailCtx.java
@@ -95,7 +95,7 @@ public class ThumbnailCtx extends ImageRegionCtx {
             }
         }
         resolutionLevel += 1;
-        if (resolutionLevel < 0) {
+        if (resolutionLevel == rds.size()) {
             throw new IllegalArgumentException(
                     "longestSide exceeds image size");
         }

--- a/src/main/java/com/glencoesoftware/omero/ms/image/region/ThumbnailsRequestHandler.java
+++ b/src/main/java/com/glencoesoftware/omero/ms/image/region/ThumbnailsRequestHandler.java
@@ -52,7 +52,7 @@ public class ThumbnailsRequestHandler extends ImageRegionRequestHandler {
     private static final org.slf4j.Logger log =
             LoggerFactory.getLogger(ThumbnailsRequestHandler.class);
 
-    /** Current thumbanil rendering context */
+    /** Current thumbnail rendering context */
     private final ThumbnailCtx thumbnailCtx;
 
     /** Image scaling service */

--- a/src/main/java/com/glencoesoftware/omero/ms/image/region/ThumbnailsRequestHandler.java
+++ b/src/main/java/com/glencoesoftware/omero/ms/image/region/ThumbnailsRequestHandler.java
@@ -47,6 +47,8 @@ import omero.model.Image;
 import omero.sys.ParametersI;
 import ucar.ma2.Array;
 
+import static omero.rtypes.unwrap;
+
 public class ThumbnailsRequestHandler extends ImageRegionRequestHandler {
 
     private static final org.slf4j.Logger log =
@@ -155,11 +157,14 @@ public class ThumbnailsRequestHandler extends ImageRegionRequestHandler {
             IPixelsPrx iPixels = sf.getPixelsService();
             List<RType> pixelsIdAndSeries = getPixelsIdAndSeries(
                 iQuery, image.getId().getValue());
-            return getRegion(iQuery, iPixels, pixelsIdAndSeries);
+            if (pixelsIdAndSeries != null && pixelsIdAndSeries.size() == 2) {
+                return getRegion(iQuery, iPixels, pixelsIdAndSeries);
+            }
+            log.debug("Cannot find Image:{}", unwrap(image.getId()));
         } catch (Exception e) {
             log.error("Error getting thumbnail {}", image.getId().getValue(), e);
-            return new byte[0];
         }
+        return new byte[0];
     }
 
     /**

--- a/src/main/java/com/glencoesoftware/omero/ms/image/region/ThumbnailsRequestHandler.java
+++ b/src/main/java/com/glencoesoftware/omero/ms/image/region/ThumbnailsRequestHandler.java
@@ -95,16 +95,14 @@ public class ThumbnailsRequestHandler extends ImageRegionRequestHandler {
 
     /**
      * Retrieves a map of JPEG thumbnails from the server.
+     * @param client OMERO client to use for querying.
      * @return Map of {@link Image} identifier to JPEG thumbnail byte array.
      */
     public Map<Long, byte[]> renderThumbnails(omero.client client) {
         try {
-            ServiceFactoryPrx sf = client.getSession();
-            IQueryPrx iQuery = sf.getQueryService();
-            IPixelsPrx iPixels = sf.getPixelsService();
             List<Image> images = getImages(client, thumbnailCtx.imageIds);
             if (images.size() != 0) {
-                return getThumbnails(iQuery, iPixels, images);
+                return getThumbnails(client, images);
             } else {
                 log.debug("Cannot find any Images with Ids {}",
                         thumbnailCtx.imageIds);
@@ -143,17 +141,18 @@ public class ThumbnailsRequestHandler extends ImageRegionRequestHandler {
 
     /**
      * Retrieves a byte array of rendered pixel data for the thumbnail
-     * @param iQuery The query service proxy
-     * @param iPixels The pixels service proxy
+     * @param client OMERO client to use for querying.
      * @param image The Image the use wants a thumbnail of
      * @param longestSide The longest side length of the final thumbnail
      * @return Byte array of jpeg thumbnail data
      * @throws IOException
      */
-    private byte[] getThumbnail(
-        IQueryPrx iQuery, IPixelsPrx iPixels, Image image)
+    private byte[] getThumbnail(omero.client client, Image image)
             throws IOException {
         try {
+            ServiceFactoryPrx sf = client.getSession();
+            IQueryPrx iQuery = sf.getQueryService();
+            IPixelsPrx iPixels = sf.getPixelsService();
             List<RType> pixelsIdAndSeries = getPixelsIdAndSeries(
                 iQuery, image.getId().getValue());
             return getRegion(iQuery, iPixels, pixelsIdAndSeries);
@@ -165,21 +164,22 @@ public class ThumbnailsRequestHandler extends ImageRegionRequestHandler {
 
     /**
      * Retrieves a map of JPEG thumbnails from ngffDir.
+     * @param client OMERO client to use for querying.
      * @param images {@link Image} list to retrieve thumbnails for.
      * @param longestSide Size to confine or upscale the longest side of each
      * thumbnail to. The other side will then proportionately, based on aspect
      * ratio, be scaled accordingly.
      * @return Map of {@link Image} identifier to JPEG thumbnail byte array.
      * @throws IOException
+     * @throws ServerError
      */
     private Map<Long, byte[]> getThumbnails(
-        IQueryPrx iQuery, IPixelsPrx iPixels, List<Image> images)
-            throws IOException {
+            omero.client client, List<Image> images)
+                    throws IOException, ServerError {
         Map<Long, byte[]> thumbnails = new HashMap<Long, byte[]>();
         for (Image image : images) {
             thumbnails.put(
-                    image.getId().getValue(),
-                    getThumbnail(iQuery, iPixels, image));
+                    image.getId().getValue(), getThumbnail(client, image));
         }
         return thumbnails;
     }

--- a/src/main/java/com/glencoesoftware/omero/ms/image/region/ThumbnailsRequestHandler.java
+++ b/src/main/java/com/glencoesoftware/omero/ms/image/region/ThumbnailsRequestHandler.java
@@ -46,7 +46,6 @@ import omero.api.ServiceFactoryPrx;
 import omero.model.Image;
 import omero.sys.ParametersI;
 import ucar.ma2.Array;
-import omeis.providers.re.codomain.ReverseIntensityContext;
 
 public class ThumbnailsRequestHandler extends ImageRegionRequestHandler {
 

--- a/src/main/java/com/glencoesoftware/omero/ms/image/region/ZarrPixelBuffer.java
+++ b/src/main/java/com/glencoesoftware/omero/ms/image/region/ZarrPixelBuffer.java
@@ -402,7 +402,7 @@ public class ZarrPixelBuffer implements PixelBuffer {
             byte[] asArray = getBytes(shape, offsets);
             PixelData d = new PixelData(
                     getPixelsType(), ByteBuffer.wrap(asArray));
-            d.setOrder(ByteOrder.nativeOrder());
+            d.setOrder(array.getByteOrder());
             return d;
         } catch (Exception e) {
             log.error("Error while retrieving pixel data", e);

--- a/src/main/java/com/glencoesoftware/omero/ms/image/region/ZarrPixelBuffer.java
+++ b/src/main/java/com/glencoesoftware/omero/ms/image/region/ZarrPixelBuffer.java
@@ -402,7 +402,7 @@ public class ZarrPixelBuffer implements PixelBuffer {
             byte[] asArray = getBytes(shape, offsets);
             PixelData d = new PixelData(
                     getPixelsType(), ByteBuffer.wrap(asArray));
-            d.setOrder(array.getByteOrder());
+            d.setOrder(ByteOrder.BIG_ENDIAN);
             return d;
         } catch (Exception e) {
             log.error("Error while retrieving pixel data", e);


### PR DESCRIPTION
This PR includes fixes for Plate based OME-NGFF data as well as some simplification refactoring and fixes for bugs with:

 * Rendering BigEndian data > 8 bits per pixel
 * Selection of resolution level for NGFF based thumbnail rendering
 * Various error handling conditions where rendering is not possible or Image/Pixels is missing
 
/cc @knabar, @erindiel, @emilroz -- May need endianness review for synchronization with PathViewer and label images