### PR TITLE
Bulk metadata queries

### DIFF
--- a/src/main/java/com/glencoesoftware/omero/ms/image/region/ThumbnailsRequestHandler.java
+++ b/src/main/java/com/glencoesoftware/omero/ms/image/region/ThumbnailsRequestHandler.java
@@ -154,12 +154,12 @@ public class ThumbnailsRequestHandler extends ImageRegionRequestHandler {
             ServiceFactoryPrx sf = client.getSession();
             IPixelsPrx iPixels = sf.getPixelsService();
             thumbnailCtx.format = "jpeg";
-                Array array = render(pixels, iPixels);
-                int[] shape = array.getShape();
-                BufferedImage image = getBufferedImage(array);
-                int longestSide = Arrays.stream(shape).max().getAsInt();
-                float scale = (float) thumbnailCtx.longestSide / longestSide;
-                return compress(iScale.scaleBufferedImage(image, scale, scale));
+            Array array = render(pixels, iPixels);
+            int[] shape = array.getShape();
+            BufferedImage image = getBufferedImage(array);
+            int longestSide = Arrays.stream(shape).max().getAsInt();
+            float scale = (float) thumbnailCtx.longestSide / longestSide;
+            return compress(iScale.scaleBufferedImage(image, scale, scale));
         } catch (Exception e) {
             span.error(e);
             log.error("Exception while rendering thumbnail", e);

--- a/src/main/java/com/glencoesoftware/omero/ms/image/region/ThumbnailsRequestHandler.java
+++ b/src/main/java/com/glencoesoftware/omero/ms/image/region/ThumbnailsRequestHandler.java
@@ -35,9 +35,7 @@ import ome.model.core.Pixels;
 import ome.model.enums.Family;
 import ome.model.enums.RenderingModel;
 import omeis.providers.re.lut.LutProvider;
-import omero.api.IPixelsPrx;
 import omero.api.IQueryPrx;
-import omero.api.ServiceFactoryPrx;
 import omero.model.Image;
 import ucar.ma2.Array;
 
@@ -151,10 +149,8 @@ public class ThumbnailsRequestHandler extends ImageRegionRequestHandler {
         try {
             span.tag("omero.image_id", pixels.getImage().getId().toString());
             span.tag("omero.pixels_id", pixels.getId().toString());
-            ServiceFactoryPrx sf = client.getSession();
-            IPixelsPrx iPixels = sf.getPixelsService();
             thumbnailCtx.format = "jpeg";
-            Array array = render(pixels, iPixels);
+            Array array = render(client, pixels);
             int[] shape = array.getShape();
             BufferedImage image = getBufferedImage(array);
             int longestSide = Arrays.stream(shape).max().getAsInt();

--- a/src/main/java/com/glencoesoftware/omero/ms/image/region/ThumbnailsRequestHandler.java
+++ b/src/main/java/com/glencoesoftware/omero/ms/image/region/ThumbnailsRequestHandler.java
@@ -32,6 +32,7 @@ import brave.Tracing;
 import ome.api.IScale;
 import ome.api.local.LocalCompress;
 import ome.model.core.Pixels;
+import ome.model.display.RenderingDef;
 import ome.model.enums.Family;
 import ome.model.enums.RenderingModel;
 import omeis.providers.re.lut.LutProvider;
@@ -150,7 +151,8 @@ public class ThumbnailsRequestHandler extends ImageRegionRequestHandler {
             span.tag("omero.image_id", pixels.getImage().getId().toString());
             span.tag("omero.pixels_id", pixels.getId().toString());
             thumbnailCtx.format = "jpeg";
-            Array array = render(client, pixels);
+            RenderingDef renderingDef = getRenderingDef(client, pixels.getId());
+            Array array = render(client, pixels, renderingDef);
             int[] shape = array.getShape();
             BufferedImage image = getBufferedImage(array);
             int longestSide = Arrays.stream(shape).max().getAsInt();

--- a/src/main/java/com/glencoesoftware/omero/ms/image/region/ThumbnailsRequestHandler.java
+++ b/src/main/java/com/glencoesoftware/omero/ms/image/region/ThumbnailsRequestHandler.java
@@ -35,7 +35,6 @@ import ome.model.core.Pixels;
 import ome.model.enums.Family;
 import ome.model.enums.RenderingModel;
 import omeis.providers.re.lut.LutProvider;
-import omero.RType;
 import omero.api.IPixelsPrx;
 import omero.api.IQueryPrx;
 import omero.api.ServiceFactoryPrx;
@@ -131,12 +130,9 @@ public class ThumbnailsRequestHandler extends ImageRegionRequestHandler {
             ServiceFactoryPrx sf = client.getSession();
             IQueryPrx iQuery = sf.getQueryService();
             IPixelsPrx iPixels = sf.getPixelsService();
-            List<RType> pixelsIdAndSeries =
-                    getPixelsIdAndSeries(iQuery, imageId);
             thumbnailCtx.format = "jpeg";
-            if (pixelsIdAndSeries != null && pixelsIdAndSeries.size() == 2) {
-                Pixels pixels = retrievePixDescription(
-                        pixelsIdAndSeries, iPixels, iQuery);
+            Pixels pixels = retrievePixDescription(iQuery, imageId);
+            if (pixels != null) {
                 Array array = render(pixels, iPixels);
                 int[] shape = array.getShape();
                 BufferedImage image = getBufferedImage(array);


### PR DESCRIPTION
Add bulk metadata queries (Pixels graph and RenderingDef graph) to avoid making many, many calls when retrieving more than one thumbnail.