### PR TITLE
Add "quantization" to features in OPTIONS

### DIFF
--- a/src/main/java/com/glencoesoftware/omero/ms/image/region/ImageRegionMicroserviceVerticle.java
+++ b/src/main/java/com/glencoesoftware/omero/ms/image/region/ImageRegionMicroserviceVerticle.java
@@ -459,7 +459,7 @@ public class ImageRegionMicroserviceVerticle extends AbstractVerticle {
                                  .add("flip")
                                  .add("mask-color")
                                  .add("png-tiles")
-                                 .add("gamma-correction"))
+                                 .add("quantization"))
                 .put("options",new JsonObject()
                                .put("maxTileLength", maxTileLength)
                                .put("maxActiveChannels", MAX_ACTIVE_CHANNELS));

--- a/src/main/java/com/glencoesoftware/omero/ms/image/region/ImageRegionMicroserviceVerticle.java
+++ b/src/main/java/com/glencoesoftware/omero/ms/image/region/ImageRegionMicroserviceVerticle.java
@@ -458,7 +458,8 @@ public class ImageRegionMicroserviceVerticle extends AbstractVerticle {
                 .put("features", new JsonArray()
                                  .add("flip")
                                  .add("mask-color")
-                                 .add("png-tiles"))
+                                 .add("png-tiles")
+                                 .add("gamma-correction"))
                 .put("options",new JsonObject()
                                .put("maxTileLength", maxTileLength)
                                .put("maxActiveChannels", MAX_ACTIVE_CHANNELS));


### PR DESCRIPTION
The presence of `"quantization"` in the list of features indicates that the microservice supports `quantization` in the `maps` URL parameter like 
```
[{"inverted":{"enabled":false},"quantization":{"family":"polynomial","coefficient":1.1}},{"inverted":{"enabled":false}},{"inverted":{"enabled":false}},{"inverted":{"enabled":false}}]
```
The available families are `linear`, `polynomial`, `exponential`, `logarithmic`