### PR TITLE
Fix lookup table handling

### DIFF
--- a/src/main/java/com/glencoesoftware/omero/ms/image/region/ImageRegionCtx.java
+++ b/src/main/java/com/glencoesoftware/omero/ms/image/region/ImageRegionCtx.java
@@ -460,7 +460,14 @@ public class ImageRegionCtx extends OmeroRequestCtx {
     }
 
     public void setColor(Renderer renderer, int idx, int c) {
-        Color color = splitHTMLColor(colors.get(idx));
+        // Special case for lookup table handling
+        String colorString = colors.get(idx);
+        if (colorString.endsWith(".lut")) {
+            renderer.setChannelLookupTable(c, colorString);
+            return;
+        }
+
+        Color color = splitHTMLColor(colorString);
         log.debug(
                 "\tColor: [{}, {}, {}, {}]",
                 color.getRed(), color.getGreen(), color.getBlue(),


### PR DESCRIPTION
The microservice does not handle lookup table "color" specifications like OMERO.py:

https://github.com/ome/omero-py/blob/ceddc2bb78db78fe0250f4ce4aa285f346b99ad7/src/omero/gateway/__init__.py#L8849-L8858

This PR fixes that problem. Relevant exception currently:

```
2021-12-01 16:32:17,129 [render-image-region-pool-15] ERROR c.g.o.m.i.r.ImageRegionRequestHandler - Exception while retrieving image region
java.lang.IllegalArgumentException: Invalid color 16_colors.lut
        at com.glencoesoftware.omero.ms.image.region.ImageRegionCtx.splitHTMLColor(ImageRegionCtx.java:411)
        at com.glencoesoftware.omero.ms.image.region.ImageRegionCtx.setColor(ImageRegionCtx.java:470)
        at com.glencoesoftware.omero.ms.image.region.ImageRegionCtx.updateSettings(ImageRegionCtx.java:503)
        at com.glencoesoftware.omero.ms.image.region.ImageRegionRequestHandler.render(ImageRegionRequestHandler.java:547)
        at com.glencoesoftware.omero.ms.image.region.ImageRegionRequestHandler.getRegion(ImageRegionRequestHandler.java:353)
        at com.glencoesoftware.omero.ms.image.region.ImageRegionRequestHandler.renderImageRegion(ImageRegionRequestHandler.java:328)
        at com.glencoesoftware.omero.ms.core.OmeroRequest.execute(OmeroRequest.java:109)
        at com.glencoesoftware.omero.ms.image.region.ImageRegionVerticle.renderImageRegion(ImageRegionVerticle.java:186)
        at com.glencoesoftware.omero.ms.image.region.ImageRegionVerticle.lambda$start$0(ImageRegionVerticle.java:134)
        at io.vertx.core.eventbus.impl.HandlerRegistration.deliver(HandlerRegistration.java:271)
        at io.vertx.core.eventbus.impl.HandlerRegistration.handle(HandlerRegistration.java:249)
        at io.vertx.core.eventbus.impl.EventBusImpl$InboundDeliveryContext.next(EventBusImpl.java:573)
        at io.vertx.core.eventbus.impl.EventBusImpl.lambda$deliverToHandler$5(EventBusImpl.java:532)
        at io.vertx.core.impl.ContextImpl.executeTask(ContextImpl.java:369)
        at io.vertx.core.impl.WorkerContext.lambda$wrapTask$0(WorkerContext.java:35)
        at io.vertx.core.impl.TaskQueue.run(TaskQueue.java:76)
        at java.base/java.util.concurrent.ThreadPoolExecutor.runWorker(ThreadPoolExecutor.java:1128)
        at java.base/java.util.concurrent.ThreadPoolExecutor$Worker.run(ThreadPoolExecutor.java:628)
        at io.netty.util.concurrent.FastThreadLocalRunnable.run(FastThreadLocalRunnable.java:30)
        at java.base/java.lang.Thread.run(Thread.java:829)
```

/cc @emilroz 