### PR TITLE
Fix imgData missing pixel sizes

### DIFF
--- a/src/test/java/com/glencoesoftware/omero/ms/image/region/ImageDataRequestHandlerTest.java
+++ b/src/test/java/com/glencoesoftware/omero/ms/image/region/ImageDataRequestHandlerTest.java
@@ -141,7 +141,6 @@ public class ImageDataRequestHandlerTest extends AbstractZarrPixelBufferTest {
 
     public static double NOMINAL_MAGNIFICATION = 123.456;
 
-
     public static boolean CH1_ACTIVE = true;
     public static double CH1_COEFFICIENT = 1.1;
     public static String CH1_COLOR = "FF0000";
@@ -163,7 +162,6 @@ public class ImageDataRequestHandlerTest extends AbstractZarrPixelBufferTest {
     public static double CH2_WINDOW_END = 31;
     public static double CH2_WINDOW_MIN = -20;
     public static double CH2_WINDOW_MAX = 20;
-
 
     public static boolean CH3_ACTIVE = true;
     public static double CH3_COEFFICIENT = 1.3;

--- a/src/test/java/com/glencoesoftware/omero/ms/image/region/ImageDataRequestHandlerTest.java
+++ b/src/test/java/com/glencoesoftware/omero/ms/image/region/ImageDataRequestHandlerTest.java
@@ -734,6 +734,27 @@ public class ImageDataRequestHandlerTest extends AbstractZarrPixelBufferTest {
     }
 
     @Test
+    public void testImageDataPixelSizePixels() throws ApiUsageException {
+        ImageDataCtx ctx = new ImageDataCtx();
+        ctx.imageId = IMAGE_ID;
+        ImageDataRequestHandler reqHandler = new ImageDataRequestHandler(
+                ctx, null, 0, true);
+        Pixels pixels = image.getPrimaryPixels();
+        pixels.setPhysicalSizeX(new LengthI(3.0, UNITS.PIXEL));
+        pixels.setPhysicalSizeY(new LengthI(4.0, UNITS.PIXEL));
+        pixels.setPhysicalSizeZ(new LengthI(5.0, UNITS.PIXEL));
+
+        JsonObject basicObj = reqHandler.populateImageData(
+                image, pixelBuffer, rdefs, OWNER_ID);
+        JsonObject pixelSizeCorrect = imgData.copy();
+        JsonObject pixSize = pixelSizeCorrect.getJsonObject("pixel_size");
+        pixSize.put("x", 3.0);
+        pixSize.put("y", 4.0);
+        pixSize.put("z", 5.0);
+        Assert.assertEquals(basicObj, pixelSizeCorrect);
+    }
+
+    @Test
     public void testImageDataTimestampOnImage() throws ApiUsageException {
         ImageDataCtx ctx = new ImageDataCtx();
         ctx.imageId = IMAGE_ID;

--- a/src/test/java/com/glencoesoftware/omero/ms/image/region/ImageDataRequestHandlerTest.java
+++ b/src/test/java/com/glencoesoftware/omero/ms/image/region/ImageDataRequestHandlerTest.java
@@ -30,7 +30,6 @@ import io.vertx.core.json.JsonArray;
 import io.vertx.core.json.JsonObject;
 import ome.io.nio.PixelBuffer;
 import omero.model.PixelsTypeI;
-import ome.units.UNITS;
 import omero.ApiUsageException;
 import omero.model.ChannelBinding;
 import omero.model.ChannelBindingI;
@@ -717,9 +716,9 @@ public class ImageDataRequestHandlerTest extends AbstractZarrPixelBufferTest {
         ImageDataRequestHandler reqHandler = new ImageDataRequestHandler(
                 ctx, null, 0, true);
         Pixels pixels = image.getPrimaryPixels();
-        pixels.setPhysicalSizeX(new LengthI(3.0, UNITS.MILLIMETER));
-        pixels.setPhysicalSizeY(new LengthI(4.0, UNITS.CENTIMETER));
-        pixels.setPhysicalSizeZ(new LengthI(5.0, UNITS.NANOMETER));
+        pixels.setPhysicalSizeX(new LengthI(3.0, UnitsLength.MILLIMETER));
+        pixels.setPhysicalSizeY(new LengthI(4.0, UnitsLength.CENTIMETER));
+        pixels.setPhysicalSizeZ(new LengthI(5.0, UnitsLength.NANOMETER));
 
         JsonObject basicObj = reqHandler.populateImageData(
                 image, pixelBuffer, rdefs, OWNER_ID);
@@ -732,23 +731,23 @@ public class ImageDataRequestHandlerTest extends AbstractZarrPixelBufferTest {
     }
 
     @Test
-    public void testImageDataPixelSizePixels() throws ApiUsageException {
+    public void testImageDataPixelSizeAsPixels() throws ApiUsageException {
         ImageDataCtx ctx = new ImageDataCtx();
         ctx.imageId = IMAGE_ID;
         ImageDataRequestHandler reqHandler = new ImageDataRequestHandler(
                 ctx, null, 0, true);
         Pixels pixels = image.getPrimaryPixels();
-        pixels.setPhysicalSizeX(new LengthI(3.0, UNITS.PIXEL));
-        pixels.setPhysicalSizeY(new LengthI(4.0, UNITS.PIXEL));
-        pixels.setPhysicalSizeZ(new LengthI(5.0, UNITS.PIXEL));
+        pixels.setPhysicalSizeX(new LengthI(3.0, UnitsLength.PIXEL));
+        pixels.setPhysicalSizeY(new LengthI(4.0, UnitsLength.PIXEL));
+        pixels.setPhysicalSizeZ(new LengthI(5.0, UnitsLength.PIXEL));
 
         JsonObject basicObj = reqHandler.populateImageData(
                 image, pixelBuffer, rdefs, OWNER_ID);
         JsonObject pixelSizeCorrect = imgData.copy();
         JsonObject pixSize = pixelSizeCorrect.getJsonObject("pixel_size");
-        pixSize.put("x", 3.0);
-        pixSize.put("y", 4.0);
-        pixSize.put("z", 5.0);
+        pixSize.putNull("x");
+        pixSize.putNull("y");
+        pixSize.putNull("z");
         Assert.assertEquals(basicObj, pixelSizeCorrect);
     }
 


### PR DESCRIPTION
Pixels sizes where the unit cannot be converted (Pixel or ReferenceFrame) should be missing (`null`) and not cause the server to throw exceptions such as:

```
2022-03-15 15:45:27,633 [render-image-region-pool-14] ERROR c.g.o.m.i.r.ImageDataRequestHandler - Error getting image data
java.lang.NullPointerException: null
        at omero.model.LengthI.<init>(LengthI.java:1460)
        at omero.model.LengthI.<init>(LengthI.java:1417)
        at com.glencoesoftware.omero.ms.image.region.ImageDataRequestHandler.getImageDataPixelSize(ImageDataRequestHandler.java:365)
        at com.glencoesoftware.omero.ms.image.region.ImageDataRequestHandler.populateImageData(ImageDataRequestHandler.java:186)
        at com.glencoesoftware.omero.ms.image.region.ImageDataRequestHandler.getImageData(ImageDataRequestHandler.java:134)
        at com.glencoesoftware.omero.ms.core.OmeroRequest.execute(OmeroRequest.java:109)
        at com.glencoesoftware.omero.ms.image.region.ImageRegionVerticle.getImageData(ImageRegionVerticle.java:385)
        at io.vertx.core.eventbus.impl.HandlerRegistration.deliver(HandlerRegistration.java:271)
        at io.vertx.core.eventbus.impl.HandlerRegistration.handle(HandlerRegistration.java:249)
        at io.vertx.core.eventbus.impl.EventBusImpl$InboundDeliveryContext.next(EventBusImpl.java:573)
        at io.vertx.core.eventbus.impl.EventBusImpl.lambda$deliverToHandler$5(EventBusImpl.java:532)
        at io.vertx.core.impl.ContextImpl.executeTask(ContextImpl.java:369)
        at io.vertx.core.impl.WorkerContext.lambda$wrapTask$0(WorkerContext.java:35)
        at io.vertx.core.impl.TaskQueue.run(TaskQueue.java:76)
        at java.base/java.util.concurrent.ThreadPoolExecutor.runWorker(ThreadPoolExecutor.java:1128)
        at java.base/java.util.concurrent.ThreadPoolExecutor$Worker.run(ThreadPoolExecutor.java:628)
        at io.netty.util.concurrent.FastThreadLocalRunnable.run(FastThreadLocalRunnable.java:30)
        at java.base/java.lang.Thread.run(Thread.java:829)
```

/cc @erindiel 