### PR TITLE
NGFF label: relax UUID requirement

### DIFF
--- a/src/main/java/com/glencoesoftware/omero/ms/image/region/PixelsService.java
+++ b/src/main/java/com/glencoesoftware/omero/ms/image/region/PixelsService.java
@@ -61,6 +61,10 @@ public class PixelsService extends ome.io.nio.PixelsService {
     private static final org.slf4j.Logger log =
             LoggerFactory.getLogger(PixelsService.class);
 
+    /* OME-NGFF identifiers */
+    public static final String NGFF_ENTITY_TYPE = "com.glencoesoftware.ngff:multiscales";
+    public static final long NGFF_ENTITY_ID = 3;
+
     /** Max Plane Width */
     private final Integer maxPlaneWidth;
 
@@ -192,6 +196,21 @@ public class PixelsService extends ome.io.nio.PixelsService {
                     object.getClass().getName(), object.getId());
             return null;
         }
+
+        String entityType = externalInfo.getEntityType();
+        if (entityType == null && entityType != NGFF_ENTITY_TYPE) {
+            log.debug("{}:{} unsupported ExternalInfo entityType {}",
+                    object.getClass().getName(), object.getId(), entityType);
+            return null;
+        }
+
+        Long entityId = externalInfo.getEntityId();
+        if (entityId == null && entityId != NGFF_ENTITY_ID) {
+            log.debug("{}:{} unsupported ExternalInfo entityId {}",
+                    object.getClass().getName(), object.getId(), entityId);
+            return null;
+        }
+
         String uri = externalInfo.getLsid();
         if (uri == null) {
             log.debug("{}:{} missing LSID",

--- a/src/main/java/com/glencoesoftware/omero/ms/image/region/PixelsService.java
+++ b/src/main/java/com/glencoesoftware/omero/ms/image/region/PixelsService.java
@@ -186,29 +186,45 @@ public class PixelsService extends ome.io.nio.PixelsService {
     private String getUri(IObject object) {
         ExternalInfo externalInfo = object.getDetails().getExternalInfo();
         if (externalInfo == null) {
-            log.debug("{}:{} missing ExternalInfo",
-                    object.getClass().getName(), object.getId());
+            log.debug(
+                "{}:{} missing ExternalInfo",
+                object.getClass().getSimpleName(), object.getId());
             return null;
         }
 
         String entityType = externalInfo.getEntityType();
-        if (entityType == null && entityType != NGFF_ENTITY_TYPE) {
-            log.debug("{}:{} unsupported ExternalInfo entityType {}",
-                    object.getClass().getName(), object.getId(), entityType);
+        if (entityType == null) {
+            log.debug(
+                "{}:{} missing ExternalInfo entityType",
+                object.getClass().getSimpleName(), object.getId());
+            return null;
+        }
+        if (!entityType.equals(NGFF_ENTITY_TYPE)) {
+            log.debug(
+                "{}:{} unsupported ExternalInfo entityType {}",
+                object.getClass().getSimpleName(), object.getId(), entityType);
             return null;
         }
 
         Long entityId = externalInfo.getEntityId();
-        if (entityId == null && entityId != NGFF_ENTITY_ID) {
-            log.debug("{}:{} unsupported ExternalInfo entityId {}",
-                    object.getClass().getName(), object.getId(), entityId);
+        if (entityType == null) {
+            log.debug(
+                "{}:{} missing ExternalInfo entityId",
+                object.getClass().getSimpleName(), object.getId());
+            return null;
+        }
+        if (!entityId.equals(NGFF_ENTITY_ID)) {
+            log.debug(
+                "{}:{} unsupported ExternalInfo entityId {}",
+                object.getClass().getSimpleName(), object.getId(), entityId);
             return null;
         }
 
         String uri = externalInfo.getLsid();
         if (uri == null) {
-            log.debug("{}:{} missing LSID",
-                    object.getClass().getName(), object.getId());
+            log.debug(
+                "{}:{} missing LSID",
+                object.getClass().getSimpleName(), object.getId());
             return null;
         }
         return uri;

--- a/src/main/java/com/glencoesoftware/omero/ms/image/region/PixelsService.java
+++ b/src/main/java/com/glencoesoftware/omero/ms/image/region/PixelsService.java
@@ -183,7 +183,7 @@ public class PixelsService extends ome.io.nio.PixelsService {
      * @return URI or <code>null</code> if the object does not contain a URI
      * in its {@link ExternalInfo}.
      */
-    private String getUri(IObject object) {
+    public String getUri(IObject object) {
         ExternalInfo externalInfo = object.getDetails().getExternalInfo();
         if (externalInfo == null) {
             log.debug(

--- a/src/main/java/com/glencoesoftware/omero/ms/image/region/ShapeMaskRequestHandler.java
+++ b/src/main/java/com/glencoesoftware/omero/ms/image/region/ShapeMaskRequestHandler.java
@@ -173,32 +173,15 @@ public class ShapeMaskRequestHandler {
      * in its {@link ExternalInfo}.
      */
     private String getUri(Mask object) {
-        ExternalInfo externalInfo = object.getDetails().getExternalInfo();
-        if (externalInfo == null) {
-            log.debug("Mask:{} missing ExternalInfo", unwrap(object.getId()));
+        if (pixelsService == null) {
             return null;
         }
-
-        String entityType = (String) unwrap(externalInfo.getEntityType());
-        if (entityType == null && entityType != pixelsService.NGFF_ENTITY_TYPE) {
-            log.debug("Mask:{} unsupported ExternalInfo entityType {}",
-                    unwrap(object.getId()), entityType);
+        try {
+            return pixelsService.getUri(
+                  (ome.model.roi.Mask) new IceMapper().reverse(object));
+        } catch (ApiUsageException e) {
             return null;
         }
-
-        Long entityId =  (Long) unwrap(externalInfo.getEntityId());
-        if (entityId == null && entityId != pixelsService.NGFF_ENTITY_ID) {
-            log.debug("Mask:{} unsupported ExternalInfo entityId {}",
-                    unwrap(object.getId()), entityId);
-            return null;
-        }
-
-        String uri = (String) unwrap(externalInfo.getLsid());
-        if (uri == null) {
-            log.debug("Mask:{} missing LSID", unwrap(object.getId()));
-            return null;
-        }
-        return uri;
     }
 
     /**

--- a/src/main/java/com/glencoesoftware/omero/ms/image/region/ShapeMaskRequestHandler.java
+++ b/src/main/java/com/glencoesoftware/omero/ms/image/region/ShapeMaskRequestHandler.java
@@ -167,12 +167,12 @@ public class ShapeMaskRequestHandler {
     }
 
     /**
-     * Retrieve {@link Mask} URI.
+     * Retrieve URI or the NGFF label image.
      * @param object loaded {@link Mask} to check for a URI
-     * @return URI or <code>null</code> if the mask does not contain a URI
-     * in its {@link ExternalInfo}.
+     * @return URI or <code>null</code> if the mask does not contain a valid
+     * NGFF URI in its {@link ExternalInfo}.
      */
-    private String getUri(Mask object) {
+    private String getLabelUri(Mask object) {
         if (pixelsService == null) {
             return null;
         }
@@ -205,7 +205,7 @@ public class ShapeMaskRequestHandler {
             // width of the data type.  If it is not so aligned or is coming
             // from an NGFF source and will not be packed bits we will need
             // to convert it to a byte mask for rendering.
-            String uri = getUri(mask);
+            String uri = getLabelUri(mask);
             int bitsPerPixel = 1;
             int width = (int) mask.getWidth().getValue();
             int height = (int) mask.getHeight().getValue();
@@ -417,7 +417,7 @@ public class ShapeMaskRequestHandler {
      */
     private byte[] getShapeMaskBytes(Mask mask)
             throws ApiUsageException, IOException {
-        String uri = getUri(mask);
+        String uri = getLabelUri(mask);
         if (uri == null) {
             return mask.getBytes();
         }
@@ -525,7 +525,7 @@ public class ShapeMaskRequestHandler {
                 .startScopedSpan("get_label_image_metadata_handler");
         try {
             Mask mask = getMask(client, shapeMaskCtx.shapeId);
-            String uri = getUri(mask);
+            String uri = getLabelUri(mask);
             if (uri == null) {
                 throw new IllegalArgumentException(
                     "No NGFF metadata for Shape:" + shapeMaskCtx.shapeId);

--- a/src/main/java/com/glencoesoftware/omero/ms/image/region/ShapeMaskRequestHandler.java
+++ b/src/main/java/com/glencoesoftware/omero/ms/image/region/ShapeMaskRequestHandler.java
@@ -417,13 +417,12 @@ public class ShapeMaskRequestHandler {
      */
     private byte[] getShapeMaskBytes(Mask mask)
             throws ApiUsageException, IOException {
-        PixelBuffer pixelBuffer;
-        try {
-            pixelBuffer = pixelsService.getLabelImagePixelBuffer(
-                  (ome.model.roi.Mask) new IceMapper().reverse(mask));
-        } catch (IllegalArgumentException e) {
+        String uri = getUri(mask);
+        if (uri == null) {
             return mask.getBytes();
         }
+        PixelBuffer pixelBuffer = pixelsService.getLabelImagePixelBuffer(
+            (ome.model.roi.Mask) new IceMapper().reverse(mask));
         int resolutionLevel =
                 shapeMaskCtx.resolution == null ? 0
                         : shapeMaskCtx.resolution;
@@ -526,6 +525,11 @@ public class ShapeMaskRequestHandler {
                 .startScopedSpan("get_label_image_metadata_handler");
         try {
             Mask mask = getMask(client, shapeMaskCtx.shapeId);
+            String uri = getUri(mask);
+            if (uri == null) {
+                throw new IllegalArgumentException(
+                    "No NGFF metadata for Shape:" + shapeMaskCtx.shapeId);
+            }
             ZarrPixelBuffer pixelBuffer =
                     pixelsService.getLabelImagePixelBuffer(
                         (ome.model.roi.Mask) new IceMapper().reverse(mask));

--- a/src/test/java/com/glencoesoftware/omero/ms/image/region/PixelsServiceTest.java
+++ b/src/test/java/com/glencoesoftware/omero/ms/image/region/PixelsServiceTest.java
@@ -1,0 +1,128 @@
+/*
+ * Copyright (C) 2023 Glencoe Software, Inc. All rights reserved.
+ *
+ * This program is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation; either version 2 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License along
+ * with this program; if not, write to the Free Software Foundation, Inc.,
+ * 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
+ */
+
+package com.glencoesoftware.omero.ms.image.region;
+
+import java.io.IOException;
+import java.io.File;
+import java.nio.file.Files;
+import java.util.UUID;
+
+import org.junit.Assert;
+import org.junit.Before;
+import org.junit.Test;
+
+import omero.ApiUsageException;
+import omero.model.ExternalInfo;
+import omero.model.ExternalInfoI;
+import omero.model.IObject;
+import omero.model.Image;
+import omero.model.ImageI;
+import omero.model.Mask;
+import omero.model.MaskI;
+import omero.util.IceMapper;
+
+import static omero.rtypes.rdouble;
+import static omero.rtypes.rlong;
+import static omero.rtypes.rstring;
+
+public class PixelsServiceTest {
+
+  private PixelsService pixelsService;
+  private String uuid = UUID.randomUUID().toString();
+  private String imageUri = "/data/ngff/image.zarr";
+  private String labelUri = imageUri + "/0/labels/" + uuid;
+  private Image image;
+  private Mask mask;
+  private String ENTITY_TYPE = "com.glencoesoftware.ngff:multiscales";
+  private int ENTITY_ID = 3;
+
+  @Before
+  public void setUp() throws IOException {
+      File pixelsDir = Files.createTempDirectory("pixels").toFile();
+      pixelsDir.deleteOnExit();
+      pixelsService = new PixelsService(
+          pixelsDir.getAbsolutePath(), 0L, null, null, null, null, 0, 0);
+      mask = new MaskI();
+      image = new ImageI();
+  }
+
+  private void addExternalInfo(IObject object, Integer entityId, String entityType, String lsid, String uuid) {
+        ExternalInfo externalInfo = new ExternalInfoI();
+        externalInfo.setEntityId(rlong(entityId));
+        externalInfo.setEntityType(rstring(entityType));
+        if (lsid != null) {
+            externalInfo.setLsid(rstring(lsid));
+        }
+        if (uuid != null) {
+            externalInfo.setUuid(rstring(uuid));
+        }
+        object.getDetails().setExternalInfo(externalInfo);
+  }
+
+  @Test
+  public void testDefault() throws ApiUsageException, IOException {
+      addExternalInfo(mask, ENTITY_ID, ENTITY_TYPE, labelUri, uuid);
+      Assert.assertEquals(pixelsService.getUri((ome.model.roi.Mask) new IceMapper().reverse(mask)), labelUri);
+
+      addExternalInfo(image, ENTITY_ID, ENTITY_TYPE, imageUri, uuid);
+      Assert.assertEquals(pixelsService.getUri((ome.model.core.Image) new IceMapper().reverse(image)), imageUri);
+  }
+
+  @Test
+  public void testGetUriNoExternalInfo() throws ApiUsageException, IOException {
+      Assert.assertNull(pixelsService.getUri((ome.model.roi.Mask) new IceMapper().reverse(mask)));
+      Assert.assertNull(pixelsService.getUri((ome.model.core.Image) new IceMapper().reverse(image)));
+  }
+
+  @Test
+  public void testGetUriNoUuid() throws ApiUsageException, IOException {
+      addExternalInfo(mask, ENTITY_ID, ENTITY_TYPE, labelUri, null);
+      Assert.assertEquals(pixelsService.getUri((ome.model.roi.Mask) new IceMapper().reverse(mask)), labelUri);
+
+      addExternalInfo(image, ENTITY_ID, ENTITY_TYPE, imageUri, null);
+      Assert.assertEquals(pixelsService.getUri((ome.model.core.Image) new IceMapper().reverse(image)), imageUri);
+  }
+
+  @Test
+  public void testGetUriNoLsid() throws ApiUsageException, IOException {
+      addExternalInfo(mask, ENTITY_ID, ENTITY_TYPE, null, uuid);
+      Assert.assertNull(pixelsService.getUri((ome.model.roi.Mask) new IceMapper().reverse(mask)));
+
+      addExternalInfo(image, ENTITY_ID, ENTITY_TYPE, null, uuid);
+      Assert.assertNull(pixelsService.getUri((ome.model.core.Image) new IceMapper().reverse(image)));
+  }
+
+  @Test
+  public void testGetUriWrongEntityType() throws ApiUsageException, IOException {
+      addExternalInfo(mask, ENTITY_ID, "multiscales", labelUri, uuid);
+      Assert.assertNull(pixelsService.getUri((ome.model.roi.Mask) new IceMapper().reverse(mask)));
+
+      addExternalInfo(image, ENTITY_ID, "multiscales", imageUri, uuid);
+      Assert.assertNull(pixelsService.getUri((ome.model.core.Image) new IceMapper().reverse(image)));
+  }
+
+  @Test
+  public void testGetUriWrongEntityId() throws ApiUsageException, IOException {
+    addExternalInfo(mask, 1, ENTITY_TYPE, labelUri, uuid);
+    Assert.assertNull(pixelsService.getUri((ome.model.roi.Mask) new IceMapper().reverse(mask)));
+
+    addExternalInfo(image, 1, ENTITY_TYPE, imageUri, uuid);
+    Assert.assertNull(pixelsService.getUri((ome.model.core.Image) new IceMapper().reverse(image)));
+  }
+}


### PR DESCRIPTION
Follow-up of #112, with the introduction of the the third generation of OME-NGFF support, `mask.externalInfo.uuid` is no longer the source of truth for distinguishing NGFF labels from regular masks. The current micro-service implementation still contains legacy assumptions and a Mask missing `externalInfo.uuid` will currently fail to load.

## Summary of changes

-  `PixelService`
   - updates `getUri` implementation to also test the values of `entityType/entityId`
   - change the scope of `getUri` to public  for consumption in `ShapeMaskRequestHandler`
   - add unit test covering the different input to `getUri`

- `ShapeMaskRequestHandler`
  - add new `getLabelUri` API which transforms a `Mask` object and returns the output of `PixelsService.getUri()`
  - replace all `getUuid` checks by `getLabelUri` for identifying NGFF labels

## Testing:

Create NGFF gen 3 labels i.e. `Mask` objects with some populated `Externalnfo` containing the expected `entityType/entityId`, a valid `lsid` pointing to the label root (local or S3) and optionally a `uuid` value  - see https://github.com/glencoesoftware/omero-ms-image-region/pull/113#issuecomment-1359201897 for an example of generation script. With this PR included, the label should be retrieved from the micro-service both with and without a `uuid` attribute