### PR TITLE
Set omero.pixeldata.ome_ngff_enabled to true by default

### DIFF
--- a/src/dist/conf/config.yaml
+++ b/src/dist/conf/config.yaml
@@ -28,7 +28,7 @@ omero.server:
     omero.pixeldata.max_plane_width: "3192"
     omero.pixeldata.max_plane_height: "3192"
     # Whether or not to enable OME-NGFF support
-    omero.pixeldata.ome_ngff_enabled: "false"
+    omero.pixeldata.ome_ngff_enabled: "true"
     # The following should be set to match your OMERO.web settings
     # See https://docs.openmicroscopy.org/omero/5.6.3/sysadmins/config.html#omero-client-viewer-interpolate-pixels
     # and https://docs.openmicroscopy.org/omero/5.6.3/sysadmins/config.html#omero-client-viewer-initial-zoom-level

--- a/src/dist/conf/config.yaml
+++ b/src/dist/conf/config.yaml
@@ -27,8 +27,6 @@ omero.server:
     omero.pixeldata.max_tile_length: "2048"
     omero.pixeldata.max_plane_width: "3192"
     omero.pixeldata.max_plane_height: "3192"
-    # Whether or not to enable OME-NGFF support
-    omero.pixeldata.ome_ngff_enabled: "true"
     # The following should be set to match your OMERO.web settings
     # See https://docs.openmicroscopy.org/omero/5.6.3/sysadmins/config.html#omero-client-viewer-interpolate-pixels
     # and https://docs.openmicroscopy.org/omero/5.6.3/sysadmins/config.html#omero-client-viewer-initial-zoom-level

--- a/src/main/java/com/glencoesoftware/omero/ms/image/region/PixelsService.java
+++ b/src/main/java/com/glencoesoftware/omero/ms/image/region/PixelsService.java
@@ -67,19 +67,13 @@ public class PixelsService extends ome.io.nio.PixelsService {
     /** Max Plane Height */
     private final Integer maxPlaneHeight;
 
-    /** Whether or not OME NGFF is enabled */
-    private final boolean isOmeNgffEnabled;
-
     public PixelsService(
             String path, long memoizerWait, FilePathResolver resolver,
             BackOff backOff, TileSizes sizes, IQuery iQuery,
-            boolean isOmeNgffEnabled,
             int maxPlaneWidth, int maxPlaneHeight) throws IOException {
         super(
             path, true, new File(new File(path), "BioFormatsCache"),
             memoizerWait, resolver, backOff, sizes, iQuery);
-        this.isOmeNgffEnabled = isOmeNgffEnabled;
-        log.info("Is OME NGFF enabled? {}", isOmeNgffEnabled);
         this.maxPlaneWidth = maxPlaneWidth;
         this.maxPlaneHeight = maxPlaneHeight;
     }
@@ -272,11 +266,9 @@ public class PixelsService extends ome.io.nio.PixelsService {
      */
     @Override
     public PixelBuffer getPixelBuffer(Pixels pixels, boolean write) {
-        if (isOmeNgffEnabled) {
-            PixelBuffer pixelBuffer = getOmeNgffPixelBuffer(pixels, write);
-            if (pixelBuffer != null) {
-                return pixelBuffer;
-            }
+        PixelBuffer pixelBuffer = getOmeNgffPixelBuffer(pixels, write);
+        if (pixelBuffer != null) {
+            return pixelBuffer;
         }
         return _getPixelBuffer(pixels, write);
     }

--- a/src/main/resources/beanRefContext.xml
+++ b/src/main/resources/beanRefContext.xml
@@ -60,7 +60,6 @@
     <constructor-arg ref="backOff"/>
     <constructor-arg ref="tileSizes"/>
     <constructor-arg><null /></constructor-arg>
-    <constructor-arg type="boolean" value="${omero.pixeldata.ome_ngff_enabled:true}"/>
     <constructor-arg value="${omero.pixeldata.max_plane_width:3192}" />
     <constructor-arg value="${omero.pixeldata.max_plane_height:3192}" />
     <property name="metrics" ref="metrics"/>

--- a/src/main/resources/beanRefContext.xml
+++ b/src/main/resources/beanRefContext.xml
@@ -60,7 +60,7 @@
     <constructor-arg ref="backOff"/>
     <constructor-arg ref="tileSizes"/>
     <constructor-arg><null /></constructor-arg>
-    <constructor-arg type="boolean" value="${omero.pixeldata.ome_ngff_enabled:false}"/>
+    <constructor-arg type="boolean" value="${omero.pixeldata.ome_ngff_enabled:true}"/>
     <constructor-arg value="${omero.pixeldata.max_plane_width:3192}" />
     <constructor-arg value="${omero.pixeldata.max_plane_height:3192}" />
     <property name="metrics" ref="metrics"/>


### PR DESCRIPTION
Proposal to update the default value of the constructor to have OME-NGFF always enabled by default. For deployments with no NGFF data, there should be no negative impact as the specific code paths should not be invoked.