### PR TITLE
Throw on Disabled AWS Credential Types

### DIFF
--- a/src/main/java/com/glencoesoftware/omero/ms/image/region/OmeroAmazonS3ClientFactory.java
+++ b/src/main/java/com/glencoesoftware/omero/ms/image/region/OmeroAmazonS3ClientFactory.java
@@ -36,6 +36,18 @@ public class OmeroAmazonS3ClientFactory extends AmazonS3ClientFactory {
 
     @Override
     protected AWSCredentialsProvider getCredentialsProvider(Properties props) {
+        // If AWS Environment or System Properties are set, throw an exception
+        // so users will know they are not supported
+        if (System.getenv("AWS_ACCESS_KEY_ID") != null ||
+                System.getenv("AWS_SECRET_ACCESS_KEY") != null ||
+                System.getenv("AWS_SESSION_TOKEN") != null ||
+                System.getProperty("aws.accessKeyId") != null ||
+                System.getProperty("aws.secretAccessKey") != null) {
+            throw new RuntimeException("AWS credentials supplied by environment variables"
+                    + " or Java system properties are not supported."
+                    + " Please use either named profiles or instance"
+                    + " profile credentials.");
+        }
         boolean anonymous = Boolean.parseBoolean(
                 (String) props.get("s3fs_anonymous"));
         if (anonymous) {


### PR DESCRIPTION
See https://github.com/glencoesoftware/omero-zarr-pixel-buffer/pull/14
We do not support providing AWS credentials via environment variables or java system properties. This PR tries to minimize confusion by explicitly throwing an exception if any of these are set. This will eliminate the possibility that users think their environment or system property credentials are being used when in fact they are not.