### PR TITLE
Consider missing channels in URL to be inactive

### DIFF
--- a/src/main/java/com/glencoesoftware/omero/ms/image/region/ImageRegionMicroserviceVerticle.java
+++ b/src/main/java/com/glencoesoftware/omero/ms/image/region/ImageRegionMicroserviceVerticle.java
@@ -481,7 +481,8 @@ public class ImageRegionMicroserviceVerticle extends AbstractVerticle {
                                .put("maxTileLength", maxTileLength)
                                .put("maxPlaneWidth", maxPlaneWidth)
                                .put("maxPlaneHeight", maxPlaneHeight)
-                               .put("maxActiveChannels", MAX_ACTIVE_CHANNELS));
+                               .put("maxActiveChannels", MAX_ACTIVE_CHANNELS))
+                .put("supportMissingChannels", true);
         if (!cacheControlHeader.equals("")) {
             resData.getJsonObject("options").put("cacheControl", cacheControlHeader);
          }

--- a/src/main/java/com/glencoesoftware/omero/ms/image/region/ImageRegionMicroserviceVerticle.java
+++ b/src/main/java/com/glencoesoftware/omero/ms/image/region/ImageRegionMicroserviceVerticle.java
@@ -476,13 +476,13 @@ public class ImageRegionMicroserviceVerticle extends AbstractVerticle {
                                  .add("flip")
                                  .add("mask-color")
                                  .add("png-tiles")
-                                 .add("quantization"))
+                                 .add("quantization")
+                                 .add("support-missing-channels"))
                 .put("options",new JsonObject()
                                .put("maxTileLength", maxTileLength)
                                .put("maxPlaneWidth", maxPlaneWidth)
                                .put("maxPlaneHeight", maxPlaneHeight)
-                               .put("maxActiveChannels", MAX_ACTIVE_CHANNELS))
-                .put("supportMissingChannels", true);
+                               .put("maxActiveChannels", MAX_ACTIVE_CHANNELS));
         if (!cacheControlHeader.equals("")) {
             resData.getJsonObject("options").put("cacheControl", cacheControlHeader);
          }

--- a/src/test/java/com/glencoesoftware/omero/ms/image/region/ImageRegionCtxTest.java
+++ b/src/test/java/com/glencoesoftware/omero/ms/image/region/ImageRegionCtxTest.java
@@ -112,20 +112,20 @@ public class ImageRegionCtxTest {
         Assert.assertEquals(imageCtx.colors.size(), 3);
         Assert.assertEquals(imageCtx.windows.size(), 3);
         Assert.assertEquals(imageCtx.channels.size(), 3);
-        Assert.assertEquals(imageCtx.colors.get(0), color0);
-        Assert.assertEquals(imageCtx.colors.get(1), color1);
-        Assert.assertEquals(imageCtx.colors.get(2), color2);
+        Assert.assertEquals(imageCtx.colors.get(channel0), color0);
+        Assert.assertEquals(imageCtx.colors.get(channel1), color1);
+        Assert.assertEquals(imageCtx.colors.get(channel2), color2);
 
         Assert.assertEquals((int) imageCtx.channels.get(0), channel0);
         Assert.assertEquals((int) imageCtx.channels.get(1), channel1);
         Assert.assertEquals((int) imageCtx.channels.get(2), channel2);
 
-        Assert.assertEquals(imageCtx.windows.get(0)[0], window0[0], 0);
-        Assert.assertEquals(imageCtx.windows.get(0)[1], window0[1], 0);
-        Assert.assertEquals(imageCtx.windows.get(1)[0], window1[0], 0);
-        Assert.assertEquals(imageCtx.windows.get(1)[1], window1[1], 0);
-        Assert.assertEquals(imageCtx.windows.get(2)[0], window2[0], 0);
-        Assert.assertEquals(imageCtx.windows.get(2)[1], window2[1], 0);
+        Assert.assertEquals(imageCtx.windows.get(channel0)[0], window0[0], 0);
+        Assert.assertEquals(imageCtx.windows.get(channel0)[1], window0[1], 0);
+        Assert.assertEquals(imageCtx.windows.get(channel1)[0], window1[0], 0);
+        Assert.assertEquals(imageCtx.windows.get(channel1)[1], window1[1], 0);
+        Assert.assertEquals(imageCtx.windows.get(channel2)[0], window2[0], 0);
+        Assert.assertEquals(imageCtx.windows.get(channel2)[1], window2[1], 0);
     }
 
     @Test(expected = IllegalArgumentException.class)
@@ -491,8 +491,9 @@ public class ImageRegionCtxTest {
     public void testWindow() {
         Renderer renderer = getRenderer();
         ImageRegionCtx ctx = new ImageRegionCtx(params, "");
-        for(int i = 0; i < ctx.windows.size(); i++) {
-            ctx.setWindow(renderer, i, i);
+        for(Integer channelId : ctx.windows.keySet()) {
+            int idx = Math.abs(channelId) - 1;
+            ctx.setWindow(renderer, channelId, idx);
         }
         ChannelBinding cb = renderer.getChannelBindings()[0];
         Assert.assertEquals(cb.getInputStart(), window0[0], 0);

--- a/src/test/java/com/glencoesoftware/omero/ms/image/region/ImageRegionCtxTest.java
+++ b/src/test/java/com/glencoesoftware/omero/ms/image/region/ImageRegionCtxTest.java
@@ -657,4 +657,112 @@ public class ImageRegionCtxTest {
         Assert.assertEquals(cb.getCoefficient(), 1.0, 0);
         Assert.assertEquals(cb.getNoiseReduction(), new Boolean(false));
     }
+
+    @Test
+    public void testMissingFirstChannel() {
+        String channelsWithFirstMissing = String.format(
+                "%d|%f:%f$%s,%d|%f:%f$%s",
+                2, window1[0], window1[1], "00FF00",
+                3, window2[0], window2[1], "0000FF");
+        params.remove("c");
+        params.add("c", channelsWithFirstMissing);
+        ImageRegionCtx ctx = new ImageRegionCtx(params, "");
+        Renderer renderer = getRenderer();
+        List<Family> families = new ArrayList<Family>();
+        families.add(new Family(Family.VALUE_LINEAR));
+        ctx.updateSettings(renderer, families, new ArrayList<RenderingModel>());
+        Assert.assertEquals(3, renderer.getChannelBindings().length);
+        ChannelBinding cb = renderer.getChannelBindings()[0];
+        Assert.assertFalse(cb.getActive());
+        Assert.assertEquals(cb.getRed(), new Integer(0));
+        Assert.assertEquals(cb.getGreen(), new Integer(0));
+        Assert.assertEquals(cb.getBlue(), new Integer(0));
+        Assert.assertEquals(cb.getAlpha(), new Integer(0));
+
+        cb = renderer.getChannelBindings()[1];
+        Assert.assertTrue(cb.getActive());
+        Assert.assertEquals(cb.getRed(), new Integer(0));
+        Assert.assertEquals(cb.getGreen(), new Integer(255));
+        Assert.assertEquals(cb.getBlue(), new Integer(0));
+        Assert.assertEquals(cb.getAlpha(), new Integer(255));
+
+        cb = renderer.getChannelBindings()[2];
+        Assert.assertTrue(cb.getActive());
+        Assert.assertEquals(cb.getRed(), new Integer(0));
+        Assert.assertEquals(cb.getGreen(), new Integer(0));
+        Assert.assertEquals(cb.getBlue(), new Integer(255));
+        Assert.assertEquals(cb.getAlpha(), new Integer(255));
+    }
+
+    @Test
+    public void testMissingSecondChannel() {
+        String channelsWithFirstMissing = String.format(
+                "%d|%f:%f$%s,%d|%f:%f$%s",
+                1, window0[0], window0[1], "FF0000",
+                3, window2[0], window2[1], "0000FF");
+        params.remove("c");
+        params.add("c", channelsWithFirstMissing);
+        ImageRegionCtx ctx = new ImageRegionCtx(params, "");
+        Renderer renderer = getRenderer();
+        List<Family> families = new ArrayList<Family>();
+        families.add(new Family(Family.VALUE_LINEAR));
+        ctx.updateSettings(renderer, families, new ArrayList<RenderingModel>());
+        Assert.assertEquals(3, renderer.getChannelBindings().length);
+        ChannelBinding cb = renderer.getChannelBindings()[0];
+        Assert.assertTrue(cb.getActive());
+        Assert.assertEquals(cb.getRed(), new Integer(255));
+        Assert.assertEquals(cb.getGreen(), new Integer(0));
+        Assert.assertEquals(cb.getBlue(), new Integer(0));
+        Assert.assertEquals(cb.getAlpha(), new Integer(255));
+
+        cb = renderer.getChannelBindings()[1];
+        Assert.assertFalse(cb.getActive());
+        Assert.assertEquals(cb.getRed(), new Integer(0));
+        Assert.assertEquals(cb.getGreen(), new Integer(0));
+        Assert.assertEquals(cb.getBlue(), new Integer(0));
+        Assert.assertEquals(cb.getAlpha(), new Integer(0));
+
+        cb = renderer.getChannelBindings()[2];
+        Assert.assertTrue(cb.getActive());
+        Assert.assertEquals(cb.getRed(), new Integer(0));
+        Assert.assertEquals(cb.getGreen(), new Integer(0));
+        Assert.assertEquals(cb.getBlue(), new Integer(255));
+        Assert.assertEquals(cb.getAlpha(), new Integer(255));
+    }
+
+    @Test
+    public void testMissingLastChannel() {
+        String channelsWithFirstMissing = String.format(
+                "%d|%f:%f$%s,%d|%f:%f$%s",
+                1, window0[0], window0[1], "FF0000",
+                2, window1[0], window1[1], "00FF00");
+        params.remove("c");
+        params.add("c", channelsWithFirstMissing);
+        ImageRegionCtx ctx = new ImageRegionCtx(params, "");
+        Renderer renderer = getRenderer();
+        List<Family> families = new ArrayList<Family>();
+        families.add(new Family(Family.VALUE_LINEAR));
+        ctx.updateSettings(renderer, families, new ArrayList<RenderingModel>());
+        Assert.assertEquals(3, renderer.getChannelBindings().length);
+        ChannelBinding cb = renderer.getChannelBindings()[0];
+        Assert.assertTrue(cb.getActive());
+        Assert.assertEquals(cb.getRed(), new Integer(255));
+        Assert.assertEquals(cb.getGreen(), new Integer(0));
+        Assert.assertEquals(cb.getBlue(), new Integer(0));
+        Assert.assertEquals(cb.getAlpha(), new Integer(255));
+
+        cb = renderer.getChannelBindings()[1];
+        Assert.assertTrue(cb.getActive());
+        Assert.assertEquals(cb.getRed(), new Integer(0));
+        Assert.assertEquals(cb.getGreen(), new Integer(255));
+        Assert.assertEquals(cb.getBlue(), new Integer(0));
+        Assert.assertEquals(cb.getAlpha(), new Integer(255));
+
+        cb = renderer.getChannelBindings()[2];
+        Assert.assertFalse(cb.getActive());
+        Assert.assertEquals(cb.getRed(), new Integer(0));
+        Assert.assertEquals(cb.getGreen(), new Integer(0));
+        Assert.assertEquals(cb.getBlue(), new Integer(0));
+        Assert.assertEquals(cb.getAlpha(), new Integer(0));
+    }
 }

--- a/src/test/java/com/glencoesoftware/omero/ms/image/region/ImageRegionCtxTest.java
+++ b/src/test/java/com/glencoesoftware/omero/ms/image/region/ImageRegionCtxTest.java
@@ -766,4 +766,40 @@ public class ImageRegionCtxTest {
         Assert.assertEquals(cb.getBlue(), new Integer(0));
         Assert.assertEquals(cb.getAlpha(), new Integer(0));
     }
+
+    @Test
+    public void testMissingAndDisabledChannel() {
+        String channelsWithFirstMissing = String.format(
+                "%d|%f:%f$%s,%d|%f:%f$%s",
+                -1, window0[0], window0[1], "FF0000",
+                2, window1[0], window1[1], "00FF00");
+        params.remove("c");
+        params.add("c", channelsWithFirstMissing);
+        ImageRegionCtx ctx = new ImageRegionCtx(params, "");
+        Renderer renderer = getRenderer();
+        List<Family> families = new ArrayList<Family>();
+        families.add(new Family(Family.VALUE_LINEAR));
+        ctx.updateSettings(renderer, families, new ArrayList<RenderingModel>());
+        Assert.assertEquals(3, renderer.getChannelBindings().length);
+        ChannelBinding cb = renderer.getChannelBindings()[0];
+        Assert.assertFalse(cb.getActive());
+        Assert.assertEquals(cb.getRed(), new Integer(0));
+        Assert.assertEquals(cb.getGreen(), new Integer(0));
+        Assert.assertEquals(cb.getBlue(), new Integer(0));
+        Assert.assertEquals(cb.getAlpha(), new Integer(0));
+
+        cb = renderer.getChannelBindings()[1];
+        Assert.assertTrue(cb.getActive());
+        Assert.assertEquals(cb.getRed(), new Integer(0));
+        Assert.assertEquals(cb.getGreen(), new Integer(255));
+        Assert.assertEquals(cb.getBlue(), new Integer(0));
+        Assert.assertEquals(cb.getAlpha(), new Integer(255));
+
+        cb = renderer.getChannelBindings()[2];
+        Assert.assertFalse(cb.getActive());
+        Assert.assertEquals(cb.getRed(), new Integer(0));
+        Assert.assertEquals(cb.getGreen(), new Integer(0));
+        Assert.assertEquals(cb.getBlue(), new Integer(0));
+        Assert.assertEquals(cb.getAlpha(), new Integer(0));
+    }
 }


### PR DESCRIPTION
Until now, if the user wanted to specify channel information in the URL, all channels had to be specified in order. The number of max active channels is limited, but all the channels must be specified nonetheless. This is a problem for images which have a very large number of channels. URLs become very long because they are full of information for inactive channels. In this PR, we have changed the microservice to assume that if a channel ID is not specified in the URL, that channel is to be inactive. Therefore, the client need only provide the list of active channels. Requesting the channels in order is not required but is recommended for URL caching. 
### Testing
Without the change, start the microservice and request a tile like this:
http://localhost:8080/webgateway/render_image_region/123/0/0/?m=c&z=1&t=1&format=jpeg&c=1|0:255$FF0000,2|0:255$00FF00,3|0:255$0000FF&tile=0,0,0,512,512
Then (for reference), mark the first channel as inactive:
http://localhost:8080/webgateway/render_image_region/123/0/0/?m=c&z=1&t=1&format=jpeg&c=-1|0:255$FF0000,2|0:255$00FF00,3|0:255$0000FF&tile=0,0,0,512,512
Then remove the first channel from the `c` parameter and make the request again:
http://localhost:8080/webgateway/render_image_region/123/0/0/?m=c&z=1&t=1&format=jpeg&c=2|0:255$00FF00,3|0:255$0000FF&tile=0,0,0,512,512
There will be an error. 
Update the code to include this PR, then make the third request again, and the image should render as if the first channel was marked as inactive.