### PR TITLE
Support missing codomain maps

### DIFF
--- a/src/main/java/com/glencoesoftware/omero/ms/image/region/ImageRegionCtx.java
+++ b/src/main/java/com/glencoesoftware/omero/ms/image/region/ImageRegionCtx.java
@@ -438,11 +438,16 @@ public class ImageRegionCtx extends OmeroRequestCtx {
     }
 
     public void setMapProperties(
-            Renderer renderer, List<Family> families, int channel) {
+            Renderer renderer, List<Family> families, int channelId) {
+        if (channelId < 0) {
+            return;
+        }
+        int channel = channelId - 1;
         if (maps != null) {
-            if (channel < maps.size()) {
+            Integer mapIdx = channels.indexOf(channelId);
+            if (mapIdx < maps.size()) {
                 Map<String, Map<String, Object>> map =
-                        maps.get(channel);
+                        maps.get(mapIdx);
                 if (map != null) {
                     if (map.containsKey("quantization")) {
                         updateQuantization(renderer, families, channel, map);
@@ -510,7 +515,7 @@ public class ImageRegionCtx extends OmeroRequestCtx {
                 if (colors != null) {
                     setColor(renderer, urlChannelId, c);
                 }
-                setMapProperties(renderer, families, c);
+                setMapProperties(renderer, families, urlChannelId);
             }
         }
         for (RenderingModel renderingModel : renderingModels) {

--- a/src/main/java/com/glencoesoftware/omero/ms/image/region/ImageRegionCtx.java
+++ b/src/main/java/com/glencoesoftware/omero/ms/image/region/ImageRegionCtx.java
@@ -80,8 +80,9 @@ public class ImageRegionCtx extends OmeroRequestCtx {
     /** Color mode (g == grey scale; c == rgb) */
     public String m;
 
-    /** Codomain maps */
-    public List<Map<String, Map<String, Object>>> maps;
+    /** Codomain maps - Keyed on Channel */
+    public Map<Integer, Map<String, Map<String, Object>>> maps =
+            new HashMap<Integer, Map<String, Map<String, Object>>>();
 
     /** Compression quality */
     public Float compressionQuality;
@@ -142,13 +143,22 @@ public class ImageRegionCtx extends OmeroRequestCtx {
         getCompressionQualityFromString(params.get("q"));
         getInvertedAxisFromString(params.get("ia"));
         getProjectionFromString(params.get("p"));
-        String maps = params.get("maps");
+        String mapsString = params.get("maps");
         String flip = Optional.ofNullable(params.get("flip"))
                 .orElse("").toLowerCase();
         flipHorizontal = flip.contains("h");
         flipVertical = flip.contains("v");
-        if (maps != null) {
-            this.maps = Json.decodeValue(maps, List.class);
+        if (mapsString != null) {
+            List<Map<String, Map<String, Object>>> mapsList =
+                    Json.decodeValue(mapsString, List.class);
+            if (mapsList.size() != channels.size()) {
+                throw new IllegalArgumentException("Must provide codomain map"
+                        + " for all provided channels or none");
+            }
+            for (int i = 0; i < channels.size(); i++) {
+                Integer c = channels.get(i);
+                maps.put(c, mapsList.get(i));
+            }
         }
         format = Optional.ofNullable(params.get("format")).orElse("jpeg");
 
@@ -439,15 +449,11 @@ public class ImageRegionCtx extends OmeroRequestCtx {
 
     public void setMapProperties(
             Renderer renderer, List<Family> families, int channelId) {
-        if (channelId < 0) {
-            return;
-        }
-        int channel = channelId - 1;
+        int channel = Math.abs(channelId) - 1;
         if (maps != null) {
-            Integer mapIdx = channels.indexOf(channelId);
-            if (mapIdx < maps.size()) {
+            if (maps.containsKey(channelId)) {
                 Map<String, Map<String, Object>> map =
-                        maps.get(mapIdx);
+                        maps.get(channelId);
                 if (map != null) {
                     if (map.containsKey("quantization")) {
                         updateQuantization(renderer, families, channel, map);

--- a/src/test/java/com/glencoesoftware/omero/ms/image/region/ImageRegionCtxTest.java
+++ b/src/test/java/com/glencoesoftware/omero/ms/image/region/ImageRegionCtxTest.java
@@ -677,6 +677,36 @@ public class ImageRegionCtxTest {
     }
 
     @Test
+    public void testEmptyMaps() {
+        String maps = "[{},"
+            + "{\"reverse\": {\"enabled\": false}, \"quantization\" :{\"family\":\"exponential\",\"coefficient\":1.8}},"
+            + "{}]";
+        params.remove("maps");
+        params.add("maps", maps);
+        ImageRegionCtx ctx = new ImageRegionCtx(params, "");
+        Renderer renderer = getRenderer();
+        List<Family> families = new ArrayList<Family>();
+        families.add(new Family(Family.VALUE_LINEAR));
+        families.add(new Family(Family.VALUE_POLYNOMIAL));
+        families.add(new Family(Family.VALUE_EXPONENTIAL));
+        ctx.updateSettings(renderer, families, new ArrayList<RenderingModel>());
+        ChannelBinding cb = renderer.getChannelBindings()[0];
+        Assert.assertEquals("linear", cb.getFamily().getValue());
+        Assert.assertEquals(cb.getCoefficient(), 1.0, 0);
+        Assert.assertEquals(cb.getNoiseReduction(), new Boolean(false));
+
+        cb = renderer.getChannelBindings()[1];
+        Assert.assertEquals("exponential", cb.getFamily().getValue());
+        Assert.assertEquals(cb.getCoefficient(), 1.8, 0);
+        Assert.assertEquals(cb.getNoiseReduction(), new Boolean(false));
+
+        cb = renderer.getChannelBindings()[2];
+        Assert.assertEquals("linear", cb.getFamily().getValue());
+        Assert.assertEquals(cb.getCoefficient(), 1.0, 0);
+        Assert.assertEquals(cb.getNoiseReduction(), new Boolean(false));
+    }
+
+    @Test
     public void testMissingFirstChannel() {
         String channelsWithFirstMissing = String.format(
                 "%d|%f:%f$%s,%d|%f:%f$%s",

--- a/src/test/java/com/glencoesoftware/omero/ms/image/region/ImageRegionCtxTest.java
+++ b/src/test/java/com/glencoesoftware/omero/ms/image/region/ImageRegionCtxTest.java
@@ -281,7 +281,8 @@ public class ImageRegionCtxTest {
                 data, ImageRegionCtx.class);
         Assert.assertNotNull(imageCtxDecoded.maps);
         Assert.assertEquals(3, imageCtxDecoded.maps.size());
-        for (Map<String, Map<String, Object>> map : imageCtxDecoded.maps) {
+        for (Integer i : imageCtxDecoded.maps.keySet()) {
+            Map<String, Map<String, Object>> map = imageCtxDecoded.maps.get(i);
             Map<String, Object> reverse = map.get("reverse");
             Boolean enabled = (Boolean) reverse.get("enabled");
             Assert.assertFalse(enabled);
@@ -510,7 +511,9 @@ public class ImageRegionCtxTest {
 
     @Test
     public void testMapsLinear() {
-        String maps = "[{\"reverse\": {\"enabled\": false}, \"quantization\" :{\"family\":\"linear\",\"coefficient\":1.8}}]";
+        String maps = "[{\"reverse\": {\"enabled\": false}, \"quantization\" :{\"family\":\"linear\",\"coefficient\":1.8}},"
+            + "{\"reverse\": {\"enabled\": false}},"
+            + "{\"reverse\": {\"enabled\": false}}]";
         params.remove("maps");
         params.add("maps", maps);
         ImageRegionCtx ctx = new ImageRegionCtx(params, "");
@@ -520,7 +523,7 @@ public class ImageRegionCtxTest {
         families.add(new Family(Family.VALUE_POLYNOMIAL));
         families.add(new Family(Family.VALUE_LOGARITHMIC));
         families.add(new Family(Family.VALUE_EXPONENTIAL));
-        ctx.setMapProperties(renderer, families, 0);
+        ctx.setMapProperties(renderer, families, -1);
         ChannelBinding cb = renderer.getChannelBindings()[0];
         Assert.assertEquals(cb.getFamily().getValue(), "linear");
         Assert.assertEquals(cb.getCoefficient(), 1.0, 0);
@@ -529,7 +532,9 @@ public class ImageRegionCtxTest {
 
     @Test
     public void testMapsPolynomial() {
-        String maps = "[{\"reverse\": {\"enabled\": false}, \"quantization\" :{\"family\":\"polynomial\",\"coefficient\":1.8}}]";
+        String maps = "[{\"reverse\": {\"enabled\": false}, \"quantization\" :{\"family\":\"polynomial\",\"coefficient\":1.8}},"
+                + "{\"reverse\": {\"enabled\": false}},"
+                + "{\"reverse\": {\"enabled\": false}}]";
         params.remove("maps");
         params.add("maps", maps);
         ImageRegionCtx ctx = new ImageRegionCtx(params, "");
@@ -539,7 +544,7 @@ public class ImageRegionCtxTest {
         families.add(new Family(Family.VALUE_POLYNOMIAL));
         families.add(new Family(Family.VALUE_LOGARITHMIC));
         families.add(new Family(Family.VALUE_EXPONENTIAL));
-        ctx.setMapProperties(renderer, families, 0);
+        ctx.setMapProperties(renderer, families, -1);
         ChannelBinding cb = renderer.getChannelBindings()[0];
         Assert.assertEquals(cb.getFamily().getValue(), "polynomial");
         Assert.assertEquals(cb.getCoefficient(), 1.8, 0);
@@ -548,7 +553,9 @@ public class ImageRegionCtxTest {
 
     @Test
     public void testMapsPolynomialIntegerCoefficient() {
-        String maps = "[{\"reverse\": {\"enabled\": false}, \"quantization\" :{\"family\":\"polynomial\",\"coefficient\":1}}]";
+        String maps = "[{\"reverse\": {\"enabled\": false}, \"quantization\" :{\"family\":\"polynomial\",\"coefficient\":1}},"
+            + "{\"reverse\": {\"enabled\": false}},"
+            + "{\"reverse\": {\"enabled\": false}}]";
         params.remove("maps");
         params.add("maps", maps);
         ImageRegionCtx ctx = new ImageRegionCtx(params, "");
@@ -558,7 +565,7 @@ public class ImageRegionCtxTest {
         families.add(new Family(Family.VALUE_POLYNOMIAL));
         families.add(new Family(Family.VALUE_LOGARITHMIC));
         families.add(new Family(Family.VALUE_EXPONENTIAL));
-        ctx.setMapProperties(renderer, families, 0);
+        ctx.setMapProperties(renderer, families, -1);
         ChannelBinding cb = renderer.getChannelBindings()[0];
         Assert.assertEquals(cb.getFamily().getValue(), "polynomial");
         Assert.assertEquals(cb.getCoefficient(), 1.0, 0);
@@ -567,7 +574,9 @@ public class ImageRegionCtxTest {
 
     @Test
     public void testMapsLogarithmic() {
-        String maps = "[{\"reverse\": {\"enabled\": false}, \"quantization\" :{\"family\":\"logarithmic\",\"coefficient\":1.8}}]";
+        String maps = "[{\"reverse\": {\"enabled\": false}, \"quantization\" :{\"family\":\"logarithmic\",\"coefficient\":1.8}},"
+            + "{\"reverse\": {\"enabled\": false}},"
+            + "{\"reverse\": {\"enabled\": false}}]";
         params.remove("maps");
         params.add("maps", maps);
         ImageRegionCtx ctx = new ImageRegionCtx(params, "");
@@ -577,7 +586,7 @@ public class ImageRegionCtxTest {
         families.add(new Family(Family.VALUE_POLYNOMIAL));
         families.add(new Family(Family.VALUE_LOGARITHMIC));
         families.add(new Family(Family.VALUE_EXPONENTIAL));
-        ctx.setMapProperties(renderer, families, 0);
+        ctx.setMapProperties(renderer, families, -1);
         ChannelBinding cb = renderer.getChannelBindings()[0];
         Assert.assertEquals(cb.getFamily().getValue(), "logarithmic");
         Assert.assertEquals(cb.getCoefficient(), 1.8, 0);
@@ -586,7 +595,9 @@ public class ImageRegionCtxTest {
 
     @Test
     public void testMapsLogarithmicNoCoefficient() {
-        String maps = "[{\"reverse\": {\"enabled\": false}, \"quantization\" :{\"family\":\"logarithmic\"}}]";
+        String maps = "[{\"reverse\": {\"enabled\": false}, \"quantization\" :{\"family\":\"logarithmic\"}},"
+            + "{\"reverse\": {\"enabled\": false}},"
+            + "{\"reverse\": {\"enabled\": false}}]";
         params.remove("maps");
         params.add("maps", maps);
         ImageRegionCtx ctx = new ImageRegionCtx(params, "");
@@ -596,7 +607,7 @@ public class ImageRegionCtxTest {
         families.add(new Family(Family.VALUE_POLYNOMIAL));
         families.add(new Family(Family.VALUE_LOGARITHMIC));
         families.add(new Family(Family.VALUE_EXPONENTIAL));
-        ctx.setMapProperties(renderer, families, 0);
+        ctx.setMapProperties(renderer, families, -1);
         ChannelBinding cb = renderer.getChannelBindings()[0];
         Assert.assertEquals(cb.getFamily().getValue(), "logarithmic");
         Assert.assertEquals(cb.getCoefficient(), 1.0, 0);
@@ -605,7 +616,9 @@ public class ImageRegionCtxTest {
 
     @Test
     public void testMapsExponential() {
-        String maps = "[{\"reverse\": {\"enabled\": false}, \"quantization\" :{\"family\":\"exponential\",\"coefficient\":1.8}}]";
+        String maps = "[{\"reverse\": {\"enabled\": false}, \"quantization\" :{\"family\":\"exponential\",\"coefficient\":1.8}},"
+            + "{\"reverse\": {\"enabled\": false}},"
+            + "{\"reverse\": {\"enabled\": false}}]";
         params.remove("maps");
         params.add("maps", maps);
         ImageRegionCtx ctx = new ImageRegionCtx(params, "");
@@ -615,7 +628,7 @@ public class ImageRegionCtxTest {
         families.add(new Family(Family.VALUE_POLYNOMIAL));
         families.add(new Family(Family.VALUE_LOGARITHMIC));
         families.add(new Family(Family.VALUE_EXPONENTIAL));
-        ctx.setMapProperties(renderer, families, 0);
+        ctx.setMapProperties(renderer, families, -1);
         ChannelBinding cb = renderer.getChannelBindings()[0];
         Assert.assertEquals(cb.getFamily().getValue(), "exponential");
         Assert.assertEquals(cb.getCoefficient(), 1.8, 0);
@@ -624,7 +637,9 @@ public class ImageRegionCtxTest {
 
     @Test(expected = IllegalArgumentException.class)
     public void testMapsExponentialNegativeCoefficient() {
-        String maps = "[{\"reverse\": {\"enabled\": false}, \"quantization\" :{\"family\":\"exponential\",\"coefficient\":-1.8}}]";
+        String maps = "[{\"reverse\": {\"enabled\": false}, \"quantization\" :{\"family\":\"exponential\",\"coefficient\":-1.8}},"
+            + "{\"reverse\": {\"enabled\": false}},"
+            + "{\"reverse\": {\"enabled\": false}}]";
         params.remove("maps");
         params.add("maps", maps);
         ImageRegionCtx ctx = new ImageRegionCtx(params, "");
@@ -634,7 +649,7 @@ public class ImageRegionCtxTest {
         families.add(new Family(Family.VALUE_POLYNOMIAL));
         families.add(new Family(Family.VALUE_LOGARITHMIC));
         families.add(new Family(Family.VALUE_EXPONENTIAL));
-        ctx.setMapProperties(renderer, families, 0);
+        ctx.setMapProperties(renderer, families, -1);
         ChannelBinding cb = renderer.getChannelBindings()[0];
         Assert.assertEquals(cb.getFamily().getValue(), "exponential");
         Assert.assertEquals(cb.getCoefficient(), 1.8, 0);
@@ -643,7 +658,9 @@ public class ImageRegionCtxTest {
 
     @Test
     public void testMapsMissingFamily() {
-        String maps = "[{\"reverse\": {\"enabled\": false}, \"quantization\" :{\"family\":\"exponential\",\"coefficient\":1.8}}]";
+        String maps = "[{\"reverse\": {\"enabled\": false}, \"quantization\" :{\"family\":\"exponential\",\"coefficient\":1.8}},"
+            + "{\"reverse\": {\"enabled\": false}},"
+            + "{\"reverse\": {\"enabled\": false}}]";
         params.remove("maps");
         params.add("maps", maps);
         ImageRegionCtx ctx = new ImageRegionCtx(params, "");
@@ -652,7 +669,7 @@ public class ImageRegionCtxTest {
         families.add(new Family(Family.VALUE_LINEAR));
         families.add(new Family(Family.VALUE_POLYNOMIAL));
         families.add(new Family(Family.VALUE_LOGARITHMIC));
-        ctx.setMapProperties(renderer, families, 0);
+        ctx.setMapProperties(renderer, families, -1);
         ChannelBinding cb = renderer.getChannelBindings()[0];
         Assert.assertEquals(cb.getFamily().getValue(), "linear");
         Assert.assertEquals(cb.getCoefficient(), 1.0, 0);
@@ -667,10 +684,16 @@ public class ImageRegionCtxTest {
                 3, window2[0], window2[1], "0000FF");
         params.remove("c");
         params.add("c", channelsWithFirstMissing);
+        String maps = "[{\"reverse\": {\"enabled\": false}, \"quantization\" :{\"family\":\"exponential\",\"coefficient\":1.8}},"
+                + "{\"reverse\": {\"enabled\": false}, \"quantization\" :{\"family\":\"polynomial\",\"coefficient\":1.2}}]";
+        params.remove("maps");
+        params.add("maps", maps);
         ImageRegionCtx ctx = new ImageRegionCtx(params, "");
         Renderer renderer = getRenderer();
         List<Family> families = new ArrayList<Family>();
         families.add(new Family(Family.VALUE_LINEAR));
+        families.add(new Family(Family.VALUE_POLYNOMIAL));
+        families.add(new Family(Family.VALUE_EXPONENTIAL));
         ctx.updateSettings(renderer, families, new ArrayList<RenderingModel>());
         Assert.assertEquals(3, renderer.getChannelBindings().length);
         ChannelBinding cb = renderer.getChannelBindings()[0];
@@ -686,6 +709,8 @@ public class ImageRegionCtxTest {
         Assert.assertEquals(cb.getGreen(), new Integer(255));
         Assert.assertEquals(cb.getBlue(), new Integer(0));
         Assert.assertEquals(cb.getAlpha(), new Integer(255));
+        Assert.assertEquals(cb.getFamily().getValue(), "exponential");
+        Assert.assertEquals(cb.getCoefficient(), 1.8, 0);
 
         cb = renderer.getChannelBindings()[2];
         Assert.assertTrue(cb.getActive());
@@ -693,6 +718,8 @@ public class ImageRegionCtxTest {
         Assert.assertEquals(cb.getGreen(), new Integer(0));
         Assert.assertEquals(cb.getBlue(), new Integer(255));
         Assert.assertEquals(cb.getAlpha(), new Integer(255));
+        Assert.assertEquals(cb.getFamily().getValue(), "polynomial");
+        Assert.assertEquals(cb.getCoefficient(), 1.2, 0);
     }
 
     @Test
@@ -703,10 +730,16 @@ public class ImageRegionCtxTest {
                 3, window2[0], window2[1], "0000FF");
         params.remove("c");
         params.add("c", channelsWithFirstMissing);
+        String maps = "[{\"reverse\": {\"enabled\": false}, \"quantization\" :{\"family\":\"exponential\",\"coefficient\":1.8}},"
+                + "{\"reverse\": {\"enabled\": false}, \"quantization\" :{\"family\":\"polynomial\",\"coefficient\":1.2}}]";
+        params.remove("maps");
+        params.add("maps", maps);
         ImageRegionCtx ctx = new ImageRegionCtx(params, "");
         Renderer renderer = getRenderer();
         List<Family> families = new ArrayList<Family>();
         families.add(new Family(Family.VALUE_LINEAR));
+        families.add(new Family(Family.VALUE_POLYNOMIAL));
+        families.add(new Family(Family.VALUE_EXPONENTIAL));
         ctx.updateSettings(renderer, families, new ArrayList<RenderingModel>());
         Assert.assertEquals(3, renderer.getChannelBindings().length);
         ChannelBinding cb = renderer.getChannelBindings()[0];
@@ -715,6 +748,8 @@ public class ImageRegionCtxTest {
         Assert.assertEquals(cb.getGreen(), new Integer(0));
         Assert.assertEquals(cb.getBlue(), new Integer(0));
         Assert.assertEquals(cb.getAlpha(), new Integer(255));
+        Assert.assertEquals(cb.getFamily().getValue(), "exponential");
+        Assert.assertEquals(cb.getCoefficient(), 1.8, 0);
 
         cb = renderer.getChannelBindings()[1];
         Assert.assertFalse(cb.getActive());
@@ -729,6 +764,8 @@ public class ImageRegionCtxTest {
         Assert.assertEquals(cb.getGreen(), new Integer(0));
         Assert.assertEquals(cb.getBlue(), new Integer(255));
         Assert.assertEquals(cb.getAlpha(), new Integer(255));
+        Assert.assertEquals(cb.getFamily().getValue(), "polynomial");
+        Assert.assertEquals(cb.getCoefficient(), 1.2, 0);
     }
 
     @Test
@@ -739,10 +776,16 @@ public class ImageRegionCtxTest {
                 2, window1[0], window1[1], "00FF00");
         params.remove("c");
         params.add("c", channelsWithFirstMissing);
+        String maps = "[{\"reverse\": {\"enabled\": false}, \"quantization\" :{\"family\":\"exponential\",\"coefficient\":1.8}},"
+                + "{\"reverse\": {\"enabled\": false}, \"quantization\" :{\"family\":\"polynomial\",\"coefficient\":1.2}}]";
+        params.remove("maps");
+        params.add("maps", maps);
         ImageRegionCtx ctx = new ImageRegionCtx(params, "");
         Renderer renderer = getRenderer();
         List<Family> families = new ArrayList<Family>();
         families.add(new Family(Family.VALUE_LINEAR));
+        families.add(new Family(Family.VALUE_POLYNOMIAL));
+        families.add(new Family(Family.VALUE_EXPONENTIAL));
         ctx.updateSettings(renderer, families, new ArrayList<RenderingModel>());
         Assert.assertEquals(3, renderer.getChannelBindings().length);
         ChannelBinding cb = renderer.getChannelBindings()[0];
@@ -751,6 +794,8 @@ public class ImageRegionCtxTest {
         Assert.assertEquals(cb.getGreen(), new Integer(0));
         Assert.assertEquals(cb.getBlue(), new Integer(0));
         Assert.assertEquals(cb.getAlpha(), new Integer(255));
+        Assert.assertEquals(cb.getFamily().getValue(), "exponential");
+        Assert.assertEquals(cb.getCoefficient(), 1.8, 0);
 
         cb = renderer.getChannelBindings()[1];
         Assert.assertTrue(cb.getActive());
@@ -758,6 +803,8 @@ public class ImageRegionCtxTest {
         Assert.assertEquals(cb.getGreen(), new Integer(255));
         Assert.assertEquals(cb.getBlue(), new Integer(0));
         Assert.assertEquals(cb.getAlpha(), new Integer(255));
+        Assert.assertEquals(cb.getFamily().getValue(), "polynomial");
+        Assert.assertEquals(cb.getCoefficient(), 1.2, 0);
 
         cb = renderer.getChannelBindings()[2];
         Assert.assertFalse(cb.getActive());
@@ -775,6 +822,7 @@ public class ImageRegionCtxTest {
                 2, window1[0], window1[1], "00FF00");
         params.remove("c");
         params.add("c", channelsWithFirstMissing);
+        params.remove("maps");
         ImageRegionCtx ctx = new ImageRegionCtx(params, "");
         Renderer renderer = getRenderer();
         List<Family> families = new ArrayList<Family>();
@@ -801,5 +849,16 @@ public class ImageRegionCtxTest {
         Assert.assertEquals(cb.getGreen(), new Integer(0));
         Assert.assertEquals(cb.getBlue(), new Integer(0));
         Assert.assertEquals(cb.getAlpha(), new Integer(0));
+    }
+
+    @Test(expected = IllegalArgumentException.class)
+    public void testMismatchedMapAndChannelNumbers() {
+        String channelsWithFirstMissing = String.format(
+                "%d|%f:%f$%s,%d|%f:%f$%s",
+                -1, window0[0], window0[1], "FF0000",
+                2, window1[0], window1[1], "00FF00");
+        params.remove("c");
+        params.add("c", channelsWithFirstMissing);
+        ImageRegionCtx ctx = new ImageRegionCtx(params, "");
     }
 }


### PR DESCRIPTION
Supplementary to #119 . To shorten URLs for images with large numbers of channels, we'd like to be able to omit the codomain chain information for channels which are inactive. In #119 we suggested assuming that any channel not specified in the URL is considered inactive. We propose here to do the same thing with codomain maps. Previously, we assumed that the first n codomain maps corresponded to the first n channels - if 2 maps were provided they were assigned to channels 1 and 2. With the new changes, the maps are applied to the corresponding provided channels. E.g. If the image has 6 channels and 1,3, and 5 are active, the `c` part of the query string would be like `1|0:255$FF0000,3|0:255$00FF00,5|0:255$0000FF`. The client would either provide no map query, or provide 3 elements in `maps`, like  `[{"inverted":{"enabled":false},"quantization":{"family":"polynomial","coefficient":1.2}},{"inverted":{"enabled":false}},{"inverted":{"enabled":false}}]`. The first map would be applied to channel 1, the second to channel 3, and the third to channel 5, since those were the channels specified in `c`. Note that all provided channels should specify a codomain map, including ones marked inactive with a negative index.
### Testing
With or without the change, the request:
http://localhost:8080/webgateway/render_image_region/15757/0/0/?m=c&z=1&t=1&format=jpeg&maps=[{%22inverted%22:{%22enabled%22:false}},{%22inverted%22:{%22enabled%22:false},%22quantization%22:{%22family%22:%22polynomial%22,%22coefficient%22:1.4}},{%22inverted%22:{%22enabled%22:false}}]&c=-1|0:255$FF0000,2|0:255$00FF00,3|0:255$0000FF&tile=0,0,0,512,512
Should be the same as, with the change:
http://localhost:8080/webgateway/render_image_region/15757/0/0/?m=c&z=1&t=1&format=jpeg&maps=[{%22inverted%22:{%22enabled%22:false},%22quantization%22:{%22family%22:%22polynomial%22,%22coefficient%22:1.4}},{%22inverted%22:{%22enabled%22:false}}]&c=2|0:255$00FF00,3|0:255$0000FF&tile=0,0,0,512,512