### PR TITLE
Fix default maximum number of active channels

### DIFF
--- a/src/main/java/com/glencoesoftware/omero/ms/image/region/ImageRegionMicroserviceVerticle.java
+++ b/src/main/java/com/glencoesoftware/omero/ms/image/region/ImageRegionMicroserviceVerticle.java
@@ -104,7 +104,7 @@ public class ImageRegionMicroserviceVerticle extends AbstractVerticle {
     private int DEFAULT_WORKER_POOL_SIZE;
 
     /** Default max number of channels to allow per request */
-    private int MAX_ACTIVE_CHANNELS = 10;
+    private int MAX_ACTIVE_CHANNELS;
 
     /** Zipkin HTTP Tracing*/
     private HttpTracing httpTracing;
@@ -388,7 +388,7 @@ public class ImageRegionMicroserviceVerticle extends AbstractVerticle {
                 "/webclient/get_thumbnails_ngff*")
             .handler(this::getThumbnails);
 
-        MAX_ACTIVE_CHANNELS = config.getInteger("max-active-channels", 6);
+        MAX_ACTIVE_CHANNELS = config.getInteger("max-active-channels", 10);
 
         int port = config.getInteger("port");
         log.info("Starting HTTP server *:{}", port);


### PR DESCRIPTION
The default was increased from 6 to 10 in d7a7dd8 but the default value of config.getInteger() was left unchanged to 6.

To test this change, comment out the value of `max-active-channels` in the YML config and make a request with e.g. 8 channels. With the current version of the micro-service, this should result in an error saying that up to 6 channels are supported. With this change, the request should complete as expected.