### PR TITLE
Configuration files review

### DIFF
--- a/README.md
+++ b/README.md
@@ -130,7 +130,7 @@ What follows is a snippet which can be placed in your nginx configuration,
 image region microservice server endpoint::
 
     upstream image_region_backend {
-        server 127.0.0.1:8080 fail_timeout=0 max_fails=0;
+        server 127.0.0.1:8081 fail_timeout=0 max_fails=0;
     }
 
     ...
@@ -199,10 +199,10 @@ value. This is the OMERO.web session key.
 1. Run single or multiple image region tests using `curl`::
 
         curl -H 'Cookie: sessionid=<omero_web_session_key>' \
-            http://localhost:8080/webgateway/render_image/<image_id>/<z>/<t>/
+            http://localhost:8081/webgateway/render_image/<image_id>/<z>/<t>/
 
         curl -H 'Cookie: sessionid=<omero_web_session_key>' \
-            http://localhost:8080/webgateway/render_image_region/<image_id>/<z>/<t>/?tile=0,0,0,1024,1024
+            http://localhost:8081/webgateway/render_image_region/<image_id>/<z>/<t>/?tile=0,0,0,1024,1024
 
 Eclipse Configuration
 =====================

--- a/README.md
+++ b/README.md
@@ -135,24 +135,8 @@ image region microservice server endpoint::
 
     ...
 
-    location /webgateway/render_image_region/ {
-        proxy_pass http://image_region_backend;
-    }
-
-    location /webgateway/render_image/ {
-        proxy_pass http://image_region_backend;
-    }
-
-    location /webclient/render_image_region/ {
-        proxy_pass http://image_region_backend;
-    }
-
-    location /webclient/render_image/ {
-        proxy_pass http://image_region_backend;
-    }
-
-    location /webgateway/render_shape_mask/ {
-        proxy_pass http://image_region_backend;
+    location ~ ^/(webclient|webgateway)/(render_(thumbnail_ngff|image|image_region|shape_mask)|get_thumbnails_ngff)/ {
+      proxy_pass http://image_region_backend;
     }
 
     location /omero_ms_image_region/ {
@@ -163,21 +147,6 @@ image region microservice server endpoint::
         proxy_pass http://image_region_backend;
     }
 
-    location /webgateway/render_thumbnail_ngff/ {
-        proxy_pass http://image_region_backend;
-    }
-
-    location /webclient/render_thumbnail_ngff/ {
-        proxy_pass http://image_region_backend;
-    }
-
-    location /webgateway/get_thumbnails_ngff/ {
-        proxy_pass http://image_region_backend;
-    }
-
-    location /webclient/get_thumbnails_ngff/ {
-        proxy_pass http://image_region_backend;
-    }
 
 Development Installation
 ========================

--- a/README.md
+++ b/README.md
@@ -159,7 +159,7 @@ image region microservice server endpoint::
         gzip on;
         gzip_min_length 0;
         gzip_proxied any;
-        gzip_types application/octet-stream text/html;
+        gzip_types application/octet-stream;
         proxy_pass http://image_region_backend;
     }
 

--- a/src/dist/conf/config.yaml
+++ b/src/dist/conf/config.yaml
@@ -23,7 +23,7 @@ omero.server:
     omero.db.user: "omero"
     omero.db.pass: "omero"
     # OMERO_HOME/lib/scripts
-    omero.script_repo_root: "/opt/omero/lib/scripts"
+    omero.script_repo_root: "/opt/omero/OMERO.current/lib/scripts"
     omero.pixeldata.max_tile_length: "2048"
     omero.pixeldata.max_plane_width: "3192"
     omero.pixeldata.max_plane_height: "3192"

--- a/src/dist/conf/config.yaml
+++ b/src/dist/conf/config.yaml
@@ -41,7 +41,7 @@ omero.web:
 
 # Configuration for zipkin http tracing
 http-tracing:
-    enabled: true
+    enabled: false
     zipkin-url: "http://localhost:9411/api/v2/spans"
 
 # Enable JMX Prometheus Metrics

--- a/src/dist/conf/config.yaml
+++ b/src/dist/conf/config.yaml
@@ -1,5 +1,5 @@
 # The port that the microservice will listen on
-port: 8080
+port: 8081
 # Configuration for request parsing limits
 #  * https://vertx.io/docs/apidocs/io/vertx/core/http/HttpServerOptions.html#setMaxInitialLineLength-int-
 #  * https://vertx.io/docs/apidocs/io/vertx/core/http/HttpServerOptions.html#setMaxHeaderSize-int-

--- a/src/dist/conf/config.yaml
+++ b/src/dist/conf/config.yaml
@@ -41,7 +41,7 @@ omero.web:
 
 # Configuration for zipkin http tracing
 http-tracing:
-    enabled: false
+    enabled: true
     zipkin-url: "http://localhost:9411/api/v2/spans"
 
 # Enable JMX Prometheus Metrics

--- a/src/dist/conf/config.yaml
+++ b/src/dist/conf/config.yaml
@@ -55,14 +55,31 @@ vertx-metrics:
 # Information about the session store.
 session-store:
     #type is either "postgres" or "redis"
-    type: "postgres"
+    type: "redis"
     #synchronicity is either "sync" or "async"
     synchronicity: "async"
     #uri for either postgres db or redis
     # * https://jdbc.postgresql.org/documentation/80/connect.html
     # * https://github.com/lettuce-io/lettuce-core/wiki/Redis-URI-and-connection-details
-    uri: "jdbc:postgresql://localhost:5432/omero_database?user=omero&password=omero"
+    # uri: "jdbc:postgresql://localhost:5432/omero_database?user=omero&password=omero"
+    # For Redis in protected mode
+    uri: "redis://:@localhost:6379/1"
+    # For Redis in non-protected mode
     # uri: "redis://:password@localhost:6379/1"
+
+redis-cache:
+    #uri: "redis://cf33da71-d81f-42e3-9932-71c82d52de32@localhost:6379/1"
+
+# In memory readability cache keyed off of OMERO session key and Image ID.
+# Enabling will speed up permissions lookups for a given OMERO session and Image
+# combination at the cost of a possibly elongated permissions window.  This
+# elongated permissions window is in effect for the time to live when the user
+# the session belongs to is removed from the group the Image belongs to.
+can-read-cache:
+    # Time (in seconds) for a cache entry to live until the lookup is performed
+    # against the server again.  0 disables the cache entirely.
+    time-to-live: 600
+    maximum-size: 10000
 
 # The string to be used as the Cache-Control header provided in responses
 cache-control-header: "private, max-age=3600"

--- a/src/dist/conf/logback.xml
+++ b/src/dist/conf/logback.xml
@@ -8,9 +8,11 @@
   </appender>
 
   <appender name="FILE" class="ch.qos.logback.core.rolling.RollingFileAppender">
+      <file>${application.home:-.}/logs/omero-ms.log</file>
       <rollingPolicy class="ch.qos.logback.core.rolling.TimeBasedRollingPolicy">
-            <fileNamePattern>${application.home:-.}/logs/omero-ms.%d{yyyy-MM-dd}.log</fileNamePattern>
-      </rollingPolicy>
+            <fileNamePattern>${application.home:-.}/logs/omero-ms.%d{yyyy-MM-dd}.log.gz</fileNamePattern>
+            <maxHistory>7</maxHistory>
+    </rollingPolicy>
     <encoder>
       <pattern>%date [%thread] %-5level %logger{36} - %msg%n</pattern>
     </encoder>
@@ -21,6 +23,6 @@
   <logger name="loci.formats.Memoizer" level="INFO"/><!-- Bio-Formats memoizer -->
 
   <root level="info">
-    <appender-ref ref="STDOUT" />
+    <appender-ref ref="FILE" />
   </root>
 </configuration>


### PR DESCRIPTION
After a review of the typical micro-service configurations with @stick, this attempts to port most of the changes back into the micro-service itself. The intent is to have the micro-service archive ship configurations as close as possibly to the default used for standard installations.

Summary of changes:

- add a default logback configuration which match typical production behavior: current log is simply called `omero-ms.log`, rotated daily including gzipping and only keeps logs for a week
- the Nginx stanza in the README is reviewed to use a shorter version making use of regex matches and to remove the unnecessary `text/html` value in `gzip_types`
- switch the default port to 8081 as 8080 is typically used for the thumbnail micro-service
- update the configuration to point at the standard script location and enable HTTP tracing by default
- change the default session store configuration to use Redis in protected mode