### PR TITLE
Add Histogram JSON Endpoint

### DIFF
--- a/README.md
+++ b/README.md
@@ -136,7 +136,7 @@ image region microservice server endpoint::
     ...
 
 
-    location ~ ^/(webclient|webgateway)/(render_(thumbnail_ngff|image|image_region|image_region_rdef|image_rdef|shape_mask)|get_thumbnails_ngff)/ {
+    location ~ ^/(webclient|webgateway)/(render_(thumbnail_ngff|image|image_region|image_region_rdef|image_rdef|shape_mask)|get_thumbnails_ngff|histogram_json)/ {
       proxy_pass http://image_region_backend;
     }
 

--- a/src/main/java/com/glencoesoftware/omero/ms/image/region/HistogramCtx.java
+++ b/src/main/java/com/glencoesoftware/omero/ms/image/region/HistogramCtx.java
@@ -70,8 +70,18 @@ public class HistogramCtx extends MicroserviceRequestCtx {
         this.omeroSessionKey = omeroSessionKey;
         imageId = getImageIdFromString(getCheckedParam(params, "imageId"));
         c = getIntegerFromString(getCheckedParam(params, "theC"));
-        z = getIntegerFromString(getCheckedParam(params, "z"));
-        t = getIntegerFromString(getCheckedParam(params, "t"));
+        String zStr = params.get("z") == null ? params.get("theZ") : params.get("z");
+        if (zStr == null) {
+            throw new IllegalArgumentException("Must provide either 'theZ' or "
+                    + "'z' parameter");
+        }
+        z = getIntegerFromString(zStr);
+        String tStr = params.get("t") == null ? params.get("theT") : params.get("t");
+        if (tStr == null) {
+            throw new IllegalArgumentException("Must provide either 'theT' or "
+                    + "'t' parameter");
+        }
+        t = getIntegerFromString(tStr);
         maxPlaneWidth = getIntegerFromString(getCheckedParam(params, "maxPlaneWidth"));
         maxPlaneHeight = getIntegerFromString(getCheckedParam(params, "maxPlaneHeight"));
         bins = params.get("bins") == null ? 256 : getIntegerFromString(params.get("bins"));

--- a/src/main/java/com/glencoesoftware/omero/ms/image/region/HistogramCtx.java
+++ b/src/main/java/com/glencoesoftware/omero/ms/image/region/HistogramCtx.java
@@ -75,12 +75,6 @@ public class HistogramCtx extends MicroserviceRequestCtx {
         maxPlaneWidth = getIntegerFromString(getCheckedParam(params, "maxPlaneWidth"));
         maxPlaneHeight = getIntegerFromString(getCheckedParam(params, "maxPlaneHeight"));
         bins = params.get("bins") == null ? 256 : getIntegerFromString(params.get("bins"));
-        if (params.get("usePixelsTypeRange") != null) {
-            String usePixelsTypeRangeString = params.get("usePixelsTypeRange").toLowerCase();
-            if (usePixelsTypeRangeString.equals("true")) {
-                usePixelsTypeRange = true;
-            }
-        }
-
+        usePixelsTypeRange = getBooleanParameter(params, "usePixelsTypeRange");
     }
 }

--- a/src/main/java/com/glencoesoftware/omero/ms/image/region/HistogramCtx.java
+++ b/src/main/java/com/glencoesoftware/omero/ms/image/region/HistogramCtx.java
@@ -32,7 +32,7 @@ public class HistogramCtx extends MicroserviceRequestCtx {
     private static final org.slf4j.Logger log =
             LoggerFactory.getLogger(HistogramCtx.class);
 
-    /** Image ID to get image data for */
+    /** Image ID */
     public Long imageId;
 
     /** c - channel index */
@@ -67,11 +67,12 @@ public class HistogramCtx extends MicroserviceRequestCtx {
      */
     HistogramCtx(MultiMap params, String omeroSessionKey) {
         this.omeroSessionKey = omeroSessionKey;
-        getImageIdFromString(getCheckedParam(params, "imageId"));
+        imageId = getImageIdFromString(getCheckedParam(params, "imageId"));
         c = getIntegerFromString(getCheckedParam(params, "theC"));
         z = getIntegerFromString(getCheckedParam(params, "z"));
         t = getIntegerFromString(getCheckedParam(params, "t"));
         maxPlaneWidth = getIntegerFromString(getCheckedParam(params, "maxPlaneWidth"));
         maxPlaneHeight = getIntegerFromString(getCheckedParam(params, "maxPlaneHeight"));
+        bins = params.get("bins") == null ? 256 : getIntegerFromString(params.get("bins"));
     }
 }

--- a/src/main/java/com/glencoesoftware/omero/ms/image/region/HistogramCtx.java
+++ b/src/main/java/com/glencoesoftware/omero/ms/image/region/HistogramCtx.java
@@ -49,10 +49,10 @@ public class HistogramCtx extends MicroserviceRequestCtx {
     /** Max Plane Height */
     public Integer maxPlaneHeight;
 
-    /** Set histogram min and max to the channel min and max rather than
-     * the min and max values for the datatype
+    /** Set histogram min and max to the pixels type min and max rather than
+     * the min and max values for the actual pixel values
      */
-    public boolean useChannelRange = false;
+    public boolean usePixelsTypeRange = false;
 
 
     /**
@@ -75,10 +75,10 @@ public class HistogramCtx extends MicroserviceRequestCtx {
         maxPlaneWidth = getIntegerFromString(getCheckedParam(params, "maxPlaneWidth"));
         maxPlaneHeight = getIntegerFromString(getCheckedParam(params, "maxPlaneHeight"));
         bins = params.get("bins") == null ? 256 : getIntegerFromString(params.get("bins"));
-        if (params.get("useChannelRange") != null) {
-            String useChannelRangeString = params.get("useChannelRange").toLowerCase();
-            if (useChannelRangeString.equals("true")) {
-                useChannelRange = true;
+        if (params.get("usePixelsTypeRange") != null) {
+            String usePixelsTypeRangeString = params.get("usePixelsTypeRange").toLowerCase();
+            if (usePixelsTypeRangeString.equals("true")) {
+                usePixelsTypeRange = true;
             }
         }
 

--- a/src/main/java/com/glencoesoftware/omero/ms/image/region/HistogramCtx.java
+++ b/src/main/java/com/glencoesoftware/omero/ms/image/region/HistogramCtx.java
@@ -63,7 +63,7 @@ public class HistogramCtx extends MicroserviceRequestCtx {
     /**
      * Default constructor.
      * @param params {@link io.vertx.core.http.HttpServerRequest} parameters
-     * required for rendering an image region.
+     * required for retrieving the histogram.
      * @param omeroSessionKey OMERO session key.
      */
     HistogramCtx(MultiMap params, String omeroSessionKey) {

--- a/src/main/java/com/glencoesoftware/omero/ms/image/region/HistogramCtx.java
+++ b/src/main/java/com/glencoesoftware/omero/ms/image/region/HistogramCtx.java
@@ -49,6 +49,11 @@ public class HistogramCtx extends MicroserviceRequestCtx {
     /** Max Plane Height */
     public Integer maxPlaneHeight;
 
+    /** Set histogram min and max to the channel min and max rather than
+     * the min and max values for the datatype
+     */
+    public boolean useChannelRange = false;
+
 
     /**
      * Constructor for jackson to decode the object from string
@@ -70,5 +75,12 @@ public class HistogramCtx extends MicroserviceRequestCtx {
         maxPlaneWidth = getIntegerFromString(getCheckedParam(params, "maxPlaneWidth"));
         maxPlaneHeight = getIntegerFromString(getCheckedParam(params, "maxPlaneHeight"));
         bins = params.get("bins") == null ? 256 : getIntegerFromString(params.get("bins"));
+        if (params.get("useChannelRange") != null) {
+            String useChannelRangeString = params.get("useChannelRange").toLowerCase();
+            if (useChannelRangeString.equals("true")) {
+                useChannelRange = true;
+            }
+        }
+
     }
 }

--- a/src/main/java/com/glencoesoftware/omero/ms/image/region/HistogramCtx.java
+++ b/src/main/java/com/glencoesoftware/omero/ms/image/region/HistogramCtx.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2021 Glencoe Software, Inc. All rights reserved.
+ * Copyright (C) 2023 Glencoe Software, Inc. All rights reserved.
  *
  * This program is free software; you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by

--- a/src/main/java/com/glencoesoftware/omero/ms/image/region/HistogramCtx.java
+++ b/src/main/java/com/glencoesoftware/omero/ms/image/region/HistogramCtx.java
@@ -1,0 +1,77 @@
+/*
+ * Copyright (C) 2021 Glencoe Software, Inc. All rights reserved.
+ *
+ * This program is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation; either version 2 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License along
+ * with this program; if not, write to the Free Software Foundation, Inc.,
+ * 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
+ */
+
+package com.glencoesoftware.omero.ms.image.region;
+
+import java.util.Arrays;
+import java.util.List;
+
+import org.slf4j.LoggerFactory;
+
+import com.glencoesoftware.omero.ms.core.OmeroRequestCtx;
+
+import io.vertx.core.MultiMap;
+
+public class HistogramCtx extends MicroserviceRequestCtx {
+
+    private static final org.slf4j.Logger log =
+            LoggerFactory.getLogger(HistogramCtx.class);
+
+    /** Image ID to get image data for */
+    public Long imageId;
+
+    /** c - channel index */
+    public Integer c;
+
+    /** Number of bins in the histogram */
+    public Integer bins;
+
+    /** z - index */
+    public Integer z;
+
+    /** t - index */
+    public Integer t;
+
+    /** Max Plane Width */
+    public Integer maxPlaneWidth;
+
+    /** Max Plane Height */
+    public Integer maxPlaneHeight;
+
+
+    /**
+     * Constructor for jackson to decode the object from string
+     */
+    HistogramCtx() {};
+
+    /**
+     * Default constructor.
+     * @param params {@link io.vertx.core.http.HttpServerRequest} parameters
+     * required for rendering an image region.
+     * @param omeroSessionKey OMERO session key.
+     */
+    HistogramCtx(MultiMap params, String omeroSessionKey) {
+        this.omeroSessionKey = omeroSessionKey;
+        getImageIdFromString(getCheckedParam(params, "imageId"));
+        c = getIntegerFromString(getCheckedParam(params, "theC"));
+        z = getIntegerFromString(getCheckedParam(params, "z"));
+        t = getIntegerFromString(getCheckedParam(params, "t"));
+        maxPlaneWidth = getIntegerFromString(getCheckedParam(params, "maxPlaneWidth"));
+        maxPlaneHeight = getIntegerFromString(getCheckedParam(params, "maxPlaneHeight"));
+    }
+}

--- a/src/main/java/com/glencoesoftware/omero/ms/image/region/HistogramCtx.java
+++ b/src/main/java/com/glencoesoftware/omero/ms/image/region/HistogramCtx.java
@@ -28,6 +28,9 @@ public class HistogramCtx extends MicroserviceRequestCtx {
     private static final org.slf4j.Logger log =
             LoggerFactory.getLogger(HistogramCtx.class);
 
+    public static final String CACHE_KEY_FORMAT =
+            "%d:%d:%d:%d:%d";  // ImageId, c, z, t, bins
+
     /** Image ID */
     public Long imageId;
 
@@ -86,5 +89,14 @@ public class HistogramCtx extends MicroserviceRequestCtx {
         maxPlaneHeight = getIntegerFromString(getCheckedParam(params, "maxPlaneHeight"));
         bins = params.get("bins") == null ? 256 : getIntegerFromString(params.get("bins"));
         usePixelsTypeRange = getBooleanParameter(params, "usePixelsTypeRange");
+    }
+
+    /**
+     * Creates a cache key for the context.
+     * @return See above.
+     */
+    public String cacheKey() {
+        return String.format(
+                CACHE_KEY_FORMAT, imageId, c, z, t, bins);
     }
 }

--- a/src/main/java/com/glencoesoftware/omero/ms/image/region/HistogramCtx.java
+++ b/src/main/java/com/glencoesoftware/omero/ms/image/region/HistogramCtx.java
@@ -18,12 +18,8 @@
 
 package com.glencoesoftware.omero.ms.image.region;
 
-import java.util.Arrays;
-import java.util.List;
 
 import org.slf4j.LoggerFactory;
-
-import com.glencoesoftware.omero.ms.core.OmeroRequestCtx;
 
 import io.vertx.core.MultiMap;
 

--- a/src/main/java/com/glencoesoftware/omero/ms/image/region/HistogramRequestHandler.java
+++ b/src/main/java/com/glencoesoftware/omero/ms/image/region/HistogramRequestHandler.java
@@ -1,0 +1,29 @@
+package com.glencoesoftware.omero.ms.image.region;
+
+import org.slf4j.LoggerFactory;
+
+import io.vertx.core.json.JsonObject;
+
+public class HistogramRequestHandler {
+
+    private static final org.slf4j.Logger log = LoggerFactory
+            .getLogger(HistogramRequestHandler.class);
+
+    /** Histogram Request Context */
+    HistogramCtx histogramCtx;
+
+    /** OMERO server pixels service. */
+    private PixelsService pixelsService;
+
+    public HistogramRequestHandler(HistogramCtx histogramCtx,
+            PixelsService pixelsService) {
+        this.histogramCtx = histogramCtx;
+        this.pixelsService = pixelsService;
+    }
+
+    public JsonObject getHistogramJson(omero.client client) {
+        JsonObject retObj = new JsonObject();
+        retObj.put("TestKey", "TestVal");
+        return retObj;
+    }
+}

--- a/src/main/java/com/glencoesoftware/omero/ms/image/region/HistogramRequestHandler.java
+++ b/src/main/java/com/glencoesoftware/omero/ms/image/region/HistogramRequestHandler.java
@@ -68,24 +68,6 @@ public class HistogramRequestHandler {
     }
 
     /**
-     * Get the min and max for the channel from the StatsInfo
-     * @param channel The channel to get the StatsInfo min and max for
-     * @return double array [min, max] if the StatsInfo is present, else null
-     */
-    private double[] getMinMaxFromStatsinfo(Channel channel) {
-        double min, max;
-        if (channel.getStatsInfo() != null) {
-            min = channel.getStatsInfo().getGlobalMin();
-            max = channel.getStatsInfo().getGlobalMax();
-            // if max == 1.0 the global min/max probably has not been
-            // calculated; fall back to plane min/max
-            if (max != 1.0)
-                return new double[] { min, max };
-        }
-        return null;
-    }
-
-    /**
      * Get the minimum and maximum value of the pixel data
      *
      * @param pd
@@ -200,12 +182,7 @@ public class HistogramRequestHandler {
                     long[] minMaxLong = FormatTools.defaultMinMax(bfPixelsType);
                     minMax = new double[] {minMaxLong[0], minMaxLong[1]};
                 } else {
-                    minMax = getMinMaxFromStatsinfo(channel);
-                    if (minMax == null) {
-                        minMax = getMinMaxFromPixelData(pd, channel);
-                    } else {
-                        fromStatsInfo = true;
-                    }
+                    minMax = getMinMaxFromPixelData(pd, channel);
                 }
                 histogramArray = getHistogramData(pd, minMax);
                 retVal.put("min", minMax[0]);

--- a/src/main/java/com/glencoesoftware/omero/ms/image/region/HistogramRequestHandler.java
+++ b/src/main/java/com/glencoesoftware/omero/ms/image/region/HistogramRequestHandler.java
@@ -169,6 +169,11 @@ public class HistogramRequestHandler {
             Map<Long, Pixels> imagePixels = retrievePixDescription(
                     iQuery, Arrays.asList(histogramCtx.imageId));
             Pixels pixels = imagePixels.get(histogramCtx.imageId);
+            if (pixels == null ||
+                   histogramCtx.z >= pixels.getSizeZ() ||
+                   histogramCtx.t >= pixels.getSizeT()) {
+                return null;
+            }
             Channel channel = pixels.getChannel(histogramCtx.c);
             try(PixelBuffer pb = getPixelBuffer(pixels)) {
                 //Find resolution level closest to max plane size without

--- a/src/main/java/com/glencoesoftware/omero/ms/image/region/HistogramRequestHandler.java
+++ b/src/main/java/com/glencoesoftware/omero/ms/image/region/HistogramRequestHandler.java
@@ -1,8 +1,27 @@
 package com.glencoesoftware.omero.ms.image.region;
 
+import java.util.Arrays;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+
 import org.slf4j.LoggerFactory;
 
+
+import brave.ScopedSpan;
+import brave.Tracer;
+import brave.Tracing;
+import io.vertx.core.json.JsonArray;
 import io.vertx.core.json.JsonObject;
+import ome.io.nio.PixelBuffer;
+import ome.model.core.Pixels;
+import ome.util.PixelData;
+import omero.ApiUsageException;
+import omero.ServerError;
+import omero.api.IQueryPrx;
+import omero.api.ServiceFactoryPrx;
+import omero.sys.ParametersI;
+import omero.util.IceMapper;
 
 public class HistogramRequestHandler {
 
@@ -21,9 +40,173 @@ public class HistogramRequestHandler {
         this.pixelsService = pixelsService;
     }
 
-    public JsonObject getHistogramJson(omero.client client) {
+    public JsonObject getHistogramJson2(omero.client client) {
         JsonObject retObj = new JsonObject();
         retObj.put("TestKey", "TestVal");
         return retObj;
     }
+
+
+    /*
+     * @login_required()
+def histogram_json(request, iid, theC, conn=None, **kwargs):
+    """
+    Returns a histogram for a single channel as a list of
+    256 values as json
+    """
+    image = conn.getObject("Image", iid)
+    if image is None:
+        raise Http404
+    maxW, maxH = conn.getMaxPlaneSize()
+    sizeX = image.getSizeX()
+    sizeY = image.getSizeY()
+    if (sizeX * sizeY) > (maxW * maxH):
+        msg = "Histogram not supported for 'big' images (over %s * %s pixels)" % (
+            maxW,
+            maxH,
+        )
+        return JsonResponse({"error": msg})
+
+    theZ = int(request.GET.get("theZ", 0))
+    theT = int(request.GET.get("theT", 0))
+    theC = int(theC)
+    binCount = int(request.GET.get("bins", 256))
+
+    # TODO: handle projection when supported by OMERO
+    data = image.getHistogram([theC], binCount, theZ=theZ, theT=theT)
+    histogram = data[theC]
+
+    return JsonResponse({"data": histogram})
+
+
+    histogram_json = url(
+    r"^histogram_json/(?P<iid>[0-9]+)/channel/(?P<theC>[0-9]+)/",
+    views.histogram_json,
+    name="histogram_json",
+)
+"""
+Gets a histogram of 256 columns (grey levels) for the chosen
+channel of an image. A single plane is specified by ?theT=1&theZ=2.
+"""
+     */
+
+
+    public JsonObject getHistogramJson(omero.client client) {
+        ScopedSpan span =
+                Tracing.currentTracer().startScopedSpan("get_histogram");
+        JsonObject retVal = new JsonObject();
+        try {
+            ServiceFactoryPrx sf = client.getSession();
+            IQueryPrx iQuery = sf.getQueryService();
+            Map<Long, Pixels> imagePixels = retrievePixDescription(
+                    iQuery, Arrays.asList(histogramCtx.imageId));
+            Pixels pixels = imagePixels.get(histogramCtx.imageId);
+            try(PixelBuffer pb = getPixelBuffer(pixels)) {
+                //Find resolution level closest to max plane size without
+                //exceeding it
+                int resolutionLevel = 0;
+                for (int i = 1; i < pb.getResolutionLevels(); i++) {
+                    pb.setResolutionLevel(i);
+                    if (pb.getSizeX() > histogramCtx.maxPlaneWidth ||
+                            pb.getSizeY() > histogramCtx.maxPlaneHeight) {
+                        break;
+                    }
+                    resolutionLevel = i;
+                }
+                pb.setResolutionLevel(resolutionLevel);
+                PixelData pd = pb.getPlane(histogramCtx.z, histogramCtx.c, histogramCtx.t);
+
+                //Calculate bin ranges
+                int[] counts = new int[histogramCtx.bins];
+                double binFactor = (double) histogramCtx.bins / Math.pow(256, pd.bytesPerPixel());
+                for (int i = 0; i < pd.size(); i++) {
+                    double val = pd.getPixelValue(i);
+                    int binVal = (int) Math.floor(val * binFactor);
+                    counts[binVal] += 1;
+                }
+                JsonArray histogramArray = new JsonArray();
+                for (int i : counts) {
+                    histogramArray.add(i);
+                }
+                retVal.put("data", histogramArray);
+            }
+        } catch (Exception e) {
+            span.error(e);
+            log.error("Exception while retrieving histogram", e);
+        } finally {
+            span.finish();
+        }
+        return retVal;
+    }
+
+    /**
+     * Get Pixels information from Image IDs
+     * @param imageIds Image IDs to get Pixels information for
+     * @param iQuery Query proxy service
+     * @return Map of Image ID vs. Populated Pixels object
+     * @throws ApiUsageException
+     * @throws ServerError
+     */
+    protected Map<Long, Pixels> retrievePixDescription(
+            IQueryPrx iQuery, List<Long> imageIds)
+                throws ApiUsageException, ServerError {
+        ScopedSpan span = Tracing.currentTracer()
+                .startScopedSpan("retrieve_pix_description");
+        try {
+            Map<String, String> ctx = new HashMap<String, String>();
+            ctx.put("omero.group", "-1");
+            span.tag("omero.image_ids", imageIds.toString());
+            // Query pulled from ome.logic.PixelsImpl and expanded to include
+            // our required Image / Plate metadata; loading both sides of the
+            // Image <--> WellSample <--> Well collection so that we can
+            // resolve our field index.
+            ParametersI params = new ParametersI();
+            params.addIds(imageIds);
+            List<Pixels> pixelsList = (List<Pixels>) new IceMapper().reverse(
+                    iQuery.findAllByQuery(
+                        "select p from Pixels as p "
+                        + "join fetch p.image as i "
+                        + "left outer join fetch i.details.externalInfo "
+                        + "left outer join fetch i.wellSamples as ws "
+                        + "left outer join fetch ws.well as w "
+                        + "left outer join fetch w.wellSamples "
+                        + "join fetch p.pixelsType "
+                        + "join fetch p.channels as c "
+                        + "join fetch c.logicalChannel as lc "
+                        + "left outer join fetch c.statsInfo "
+                        + "left outer join fetch lc.photometricInterpretation "
+                        + "left outer join fetch lc.illumination "
+                        + "left outer join fetch lc.mode "
+                        + "left outer join fetch lc.contrastMethod "
+                        + "where i.id in (:ids)", params, ctx));
+            Map<Long, Pixels> toReturn = new HashMap<Long, Pixels>();
+            for (Pixels pixels : pixelsList) {
+                toReturn.put(pixels.getImage().getId(), pixels);
+            }
+            return toReturn;
+        } finally {
+            span.finish();
+        }
+    }
+
+    /**
+     * Returns a pixel buffer for a given set of pixels.
+     * @param pixels pixels metadata
+     * @return See above.
+     * @see PixelsService#getPixelBuffer(Pixels)
+     */
+    private PixelBuffer getPixelBuffer(Pixels pixels) {
+        Tracer tracer = Tracing.currentTracer();
+        ScopedSpan span = tracer.startScopedSpan("get_pixel_buffer");
+        try {
+            span.tag("omero.pixels_id", Long.toString(pixels.getId()));
+            return pixelsService.getPixelBuffer(pixels, false);
+        } catch (Exception e) {
+            span.error(e);
+            throw e;
+        } finally {
+            span.finish();
+        }
+    }
+
 }

--- a/src/main/java/com/glencoesoftware/omero/ms/image/region/HistogramRequestHandler.java
+++ b/src/main/java/com/glencoesoftware/omero/ms/image/region/HistogramRequestHandler.java
@@ -121,9 +121,9 @@ public class HistogramRequestHandler {
      * (not necessarily full resolution)
      * @param imgHeight The sizeY of the pixel data
      * (not necessarily full resolution)
-     * @return
+     * @return {@link JsonArray} containing histogram data
      */
-    private JsonArray getHistogramData(PixelData pd, Channel channel,
+    public JsonArray getHistogramData(PixelData pd,
             double[] minMax, int imgWidth, int imgHeight) {
         int[] counts = new int[histogramCtx.bins];
 
@@ -148,7 +148,9 @@ public class HistogramRequestHandler {
                 } else {
                     //Pixel Value outside of min/max range
                     throw new IllegalArgumentException(String.format(
-                            "Image %s has pixel values %.2f outside of [%.2f, %.2f]"));
+                            "Image %d has pixel values %.2f outside of [%.2f, %.2f]",
+                            histogramCtx.imageId, pd.getPixelValue(i),
+                            minMax[0], minMax[1]));
                 }
             }
         }
@@ -208,7 +210,7 @@ public class HistogramRequestHandler {
                         fromStatsInfo = true;
                     }
                 }
-                histogramArray = getHistogramData(pd, channel, minMax,
+                histogramArray = getHistogramData(pd, minMax,
                         pb.getSizeX(),
                         pb.getSizeY());
                 retVal.put("min", minMax[0]);

--- a/src/main/java/com/glencoesoftware/omero/ms/image/region/HistogramRequestHandler.java
+++ b/src/main/java/com/glencoesoftware/omero/ms/image/region/HistogramRequestHandler.java
@@ -46,51 +46,6 @@ public class HistogramRequestHandler {
         return retObj;
     }
 
-
-    /*
-     * @login_required()
-def histogram_json(request, iid, theC, conn=None, **kwargs):
-    """
-    Returns a histogram for a single channel as a list of
-    256 values as json
-    """
-    image = conn.getObject("Image", iid)
-    if image is None:
-        raise Http404
-    maxW, maxH = conn.getMaxPlaneSize()
-    sizeX = image.getSizeX()
-    sizeY = image.getSizeY()
-    if (sizeX * sizeY) > (maxW * maxH):
-        msg = "Histogram not supported for 'big' images (over %s * %s pixels)" % (
-            maxW,
-            maxH,
-        )
-        return JsonResponse({"error": msg})
-
-    theZ = int(request.GET.get("theZ", 0))
-    theT = int(request.GET.get("theT", 0))
-    theC = int(theC)
-    binCount = int(request.GET.get("bins", 256))
-
-    # TODO: handle projection when supported by OMERO
-    data = image.getHistogram([theC], binCount, theZ=theZ, theT=theT)
-    histogram = data[theC]
-
-    return JsonResponse({"data": histogram})
-
-
-    histogram_json = url(
-    r"^histogram_json/(?P<iid>[0-9]+)/channel/(?P<theC>[0-9]+)/",
-    views.histogram_json,
-    name="histogram_json",
-)
-"""
-Gets a histogram of 256 columns (grey levels) for the chosen
-channel of an image. A single plane is specified by ?theT=1&theZ=2.
-"""
-     */
-
-
     public JsonObject getHistogramJson(omero.client client) {
         ScopedSpan span =
                 Tracing.currentTracer().startScopedSpan("get_histogram");

--- a/src/main/java/com/glencoesoftware/omero/ms/image/region/HistogramRequestHandler.java
+++ b/src/main/java/com/glencoesoftware/omero/ms/image/region/HistogramRequestHandler.java
@@ -35,7 +35,6 @@ import loci.formats.FormatTools;
 import ome.io.nio.PixelBuffer;
 import ome.model.core.Channel;
 import ome.model.core.Pixels;
-import ome.model.enums.PixelsType;
 import ome.util.PixelData;
 import omeis.providers.re.metadata.StatsFactory;
 import omero.ApiUsageException;

--- a/src/main/java/com/glencoesoftware/omero/ms/image/region/HistogramRequestHandler.java
+++ b/src/main/java/com/glencoesoftware/omero/ms/image/region/HistogramRequestHandler.java
@@ -58,12 +58,6 @@ public class HistogramRequestHandler {
         this.pixelsService = pixelsService;
     }
 
-    public JsonObject getHistogramJson2(omero.client client) {
-        JsonObject retObj = new JsonObject();
-        retObj.put("TestKey", "TestVal");
-        return retObj;
-    }
-
     public JsonObject getHistogramJson(omero.client client) {
         ScopedSpan span =
                 Tracing.currentTracer().startScopedSpan("get_histogram");

--- a/src/main/java/com/glencoesoftware/omero/ms/image/region/HistogramRequestHandler.java
+++ b/src/main/java/com/glencoesoftware/omero/ms/image/region/HistogramRequestHandler.java
@@ -254,17 +254,10 @@ public class HistogramRequestHandler {
                         "select p from Pixels as p "
                         + "join fetch p.image as i "
                         + "left outer join fetch i.details.externalInfo "
-                        + "left outer join fetch i.wellSamples as ws "
-                        + "left outer join fetch ws.well as w "
-                        + "left outer join fetch w.wellSamples "
                         + "join fetch p.pixelsType "
                         + "join fetch p.channels as c "
                         + "join fetch c.logicalChannel as lc "
                         + "left outer join fetch c.statsInfo "
-                        + "left outer join fetch lc.photometricInterpretation "
-                        + "left outer join fetch lc.illumination "
-                        + "left outer join fetch lc.mode "
-                        + "left outer join fetch lc.contrastMethod "
                         + "where i.id in (:ids)", params, ctx));
             Map<Long, Pixels> toReturn = new HashMap<Long, Pixels>();
             for (Pixels pixels : pixelsList) {

--- a/src/main/java/com/glencoesoftware/omero/ms/image/region/HistogramRequestHandler.java
+++ b/src/main/java/com/glencoesoftware/omero/ms/image/region/HistogramRequestHandler.java
@@ -55,12 +55,22 @@ public class HistogramRequestHandler {
     /** OMERO server pixels service. */
     private PixelsService pixelsService;
 
+    /**
+     * Constructor. Populates histogramCtx and pixelsService
+     * @param histogramCtx
+     * @param pixelsService
+     */
     public HistogramRequestHandler(HistogramCtx histogramCtx,
             PixelsService pixelsService) {
         this.histogramCtx = histogramCtx;
         this.pixelsService = pixelsService;
     }
 
+    /**
+     * Gets the min and max values for the given pixel type
+     * @param pt The PixelsType to get the min and max for
+     * @return Size 2 double array [min, max] for the given pixel type
+     */
     private double[] getMinMaxFromPixelsType(PixelsType pt) {
         if (pt.getValue().equals(PixelsType.VALUE_BIT)) {
             return new double[] {0, 1};
@@ -85,6 +95,11 @@ public class HistogramRequestHandler {
                                            + pt.getValue());
     }
 
+    /**
+     * Get the min and max for the channel from the StatsInfo
+     * @param channel The channel to get the StatsInfo min and max for
+     * @return double array [min, max] if the StatsInfo is present, else null
+     */
     private double[] getMinMaxFromStatsinfo(Channel channel) {
         double min, max;
         if (channel.getStatsInfo() != null) {
@@ -124,6 +139,18 @@ public class HistogramRequestHandler {
         return new double[] { min, max };
     }
 
+    /**
+     * Read through the pixel data and produce histogram data reflecting
+     * the occurrance of pixel values within each bin
+     * @param pd The {@link PixelData} to get the pixel values from
+     * @param channel The {@link Channel} to get the pixel values from
+     * @param minMax The min and max to values to divide into bins
+     * @param imgWidth The sizeX of the pixel data
+     * (not necessarily full resolution)
+     * @param imgHeight The sizeY of the pixel data
+     * (not necessarily full resolution)
+     * @return
+     */
     private JsonArray getHistogramData(PixelData pd, Channel channel,
             double[] minMax, int imgWidth, int imgHeight) {
         int[] counts = new int[histogramCtx.bins];
@@ -156,6 +183,13 @@ public class HistogramRequestHandler {
         return histogramArray;
     }
 
+    /**
+     * Retrieves JSON data representing the histogram for the parameters
+     * specified in the histogramCtx
+     * @param client
+     * @return VertX {@link JsonObject} with the histogram data,
+     * the min and max, and whether it was retrieved from StatsInfo
+     */
     public JsonObject getHistogramJson(omero.client client) {
         ScopedSpan span =
                 Tracing.currentTracer().startScopedSpan("get_histogram");

--- a/src/main/java/com/glencoesoftware/omero/ms/image/region/HistogramRequestHandler.java
+++ b/src/main/java/com/glencoesoftware/omero/ms/image/region/HistogramRequestHandler.java
@@ -186,11 +186,11 @@ public class HistogramRequestHandler {
                                            histogramCtx.t);
                 JsonArray histogramArray = new JsonArray();
                 double[] minMax = null;
-                if (histogramCtx.useChannelRange) {
+                if (histogramCtx.usePixelsTypeRange) {
+                    minMax = getMaxValueForPixelsType(pixels.getPixelsType());
+                } else {
                     //TODO: Support useGlobal?
                     minMax = determineHistogramMinMax(pd, channel, false);
-                } else {
-                    minMax = getMaxValueForPixelsType(pixels.getPixelsType());
                 }
                 histogramArray = getHistogramData(pd, channel, minMax,
                         pb.getSizeX(),

--- a/src/main/java/com/glencoesoftware/omero/ms/image/region/HistogramRequestHandler.java
+++ b/src/main/java/com/glencoesoftware/omero/ms/image/region/HistogramRequestHandler.java
@@ -116,14 +116,10 @@ public class HistogramRequestHandler {
      * @param pd The {@link PixelData} to get the pixel values from
      * @param channel The {@link Channel} to get the pixel values from
      * @param minMax The min and max to values to divide into bins
-     * @param imgWidth The sizeX of the pixel data
-     * (not necessarily full resolution)
-     * @param imgHeight The sizeY of the pixel data
-     * (not necessarily full resolution)
      * @return {@link JsonArray} containing histogram data
      */
     public JsonArray getHistogramData(PixelData pd,
-            double[] minMax, int imgWidth, int imgHeight) {
+            double[] minMax) {
         int[] counts = new int[histogramCtx.bins];
 
         double min = minMax[0];
@@ -205,9 +201,7 @@ public class HistogramRequestHandler {
                         fromStatsInfo = true;
                     }
                 }
-                histogramArray = getHistogramData(pd, minMax,
-                        pb.getSizeX(),
-                        pb.getSizeY());
+                histogramArray = getHistogramData(pd, minMax);
                 retVal.put("min", minMax[0]);
                 retVal.put("max", minMax[1]);
                 retVal.put("fromStatsInfo", fromStatsInfo);

--- a/src/main/java/com/glencoesoftware/omero/ms/image/region/HistogramRequestHandler.java
+++ b/src/main/java/com/glencoesoftware/omero/ms/image/region/HistogramRequestHandler.java
@@ -1,3 +1,21 @@
+/*
+ * Copyright (C) 2023 Glencoe Software, Inc. All rights reserved.
+ *
+ * This program is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation; either version 2 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License along
+ * with this program; if not, write to the Free Software Foundation, Inc.,
+ * 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
+ */
+
 package com.glencoesoftware.omero.ms.image.region;
 
 import java.util.Arrays;

--- a/src/main/java/com/glencoesoftware/omero/ms/image/region/HistogramRequestHandler.java
+++ b/src/main/java/com/glencoesoftware/omero/ms/image/region/HistogramRequestHandler.java
@@ -163,7 +163,13 @@ public class HistogramRequestHandler {
                 //exceeding it
                 int resolutionLevel = -1;
                 for (int i = 0; i < pb.getResolutionLevels(); i++) {
-                    pb.setResolutionLevel(i);
+                    //If there's only 1 resolution level, we may have a
+                    //RomioPixelBuffer, which doesn't support setResolutionLevel,
+                    //so just check the size of the buffer
+                    //and use it if it's small enough
+                    if (pb.getResolutionLevels() > 1) {
+                        pb.setResolutionLevel(i);
+                    }
                     if (pb.getSizeX() > histogramCtx.maxPlaneWidth ||
                             pb.getSizeY() > histogramCtx.maxPlaneHeight) {
                         break;
@@ -175,7 +181,9 @@ public class HistogramRequestHandler {
                     throw new IllegalArgumentException("All resolution levels larger "
                             + "than max plane size");
                 }
-                pb.setResolutionLevel(resolutionLevel);
+                if (pb.getResolutionLevels() > 1) {
+                    pb.setResolutionLevel(resolutionLevel);
+                }
                 PixelData pd = pb.getPlane(histogramCtx.z, histogramCtx.c,
                                            histogramCtx.t);
                 JsonArray histogramArray = new JsonArray();

--- a/src/main/java/com/glencoesoftware/omero/ms/image/region/HistogramRequestHandler.java
+++ b/src/main/java/com/glencoesoftware/omero/ms/image/region/HistogramRequestHandler.java
@@ -175,7 +175,6 @@ public class HistogramRequestHandler {
                                            histogramCtx.t);
                 JsonArray histogramArray = new JsonArray();
                 double[] minMax = null;
-                boolean fromStatsInfo = false;
                 if (histogramCtx.usePixelsTypeRange) {
                     int bfPixelsType = FormatTools.pixelTypeFromString(
                             pixels.getPixelsType().getValue());
@@ -187,7 +186,6 @@ public class HistogramRequestHandler {
                 histogramArray = getHistogramData(pd, minMax);
                 retVal.put("min", minMax[0]);
                 retVal.put("max", minMax[1]);
-                retVal.put("fromStatsInfo", fromStatsInfo);
                 retVal.put("data", histogramArray);
             }
         } catch (Exception e) {

--- a/src/main/java/com/glencoesoftware/omero/ms/image/region/HistogramRequestHandler.java
+++ b/src/main/java/com/glencoesoftware/omero/ms/image/region/HistogramRequestHandler.java
@@ -132,25 +132,21 @@ public class HistogramRequestHandler {
         double range = max - min + 1;
         double binRange = range / histogramCtx.bins;
         for (int i = 0; i < pd.size(); i++) {
-            int pdx = i % imgWidth;
-            int pdy = i / imgWidth;
-            if (pdx >= 0 && pdx < (0 + imgWidth) && pdy >= 0 && pdy < (0 + imgHeight)) {
-                int bin = (int) ((pd.getPixelValue(i) - min) / binRange);
-                // if there are more bins than values (binRange < 1) the bin will be offset by -1.
-                // e.g. min=0.0, max=127.0, binCount=256: a pixel with max value 127.0 would go
-                // into bin 254 (expected: 255). Therefore increment by one for these cases.
-                if (bin > 0 && binRange < 1)
-                    bin++;
+            int bin = (int) ((pd.getPixelValue(i) - min) / binRange);
+            // if there are more bins than values (binRange < 1) the bin will be offset by -1.
+            // e.g. min=0.0, max=127.0, binCount=256: a pixel with max value 127.0 would go
+            // into bin 254 (expected: 255). Therefore increment by one for these cases.
+            if (bin > 0 && binRange < 1)
+                bin++;
 
-                if (bin >= 0 && bin < histogramCtx.bins) {
-                    counts[bin]++;
-                } else {
-                    //Pixel Value outside of min/max range
-                    throw new IllegalArgumentException(String.format(
-                            "Image %d has pixel values %.2f outside of [%.2f, %.2f]",
-                            histogramCtx.imageId, pd.getPixelValue(i),
-                            minMax[0], minMax[1]));
-                }
+            if (bin >= 0 && bin < histogramCtx.bins) {
+                counts[bin]++;
+            } else {
+                //Pixel Value outside of min/max range
+                throw new IllegalArgumentException(String.format(
+                        "Image %d has pixel values %.2f outside of [%.2f, %.2f]",
+                        histogramCtx.imageId, pd.getPixelValue(i),
+                        minMax[0], minMax[1]));
             }
         }
         JsonArray histogramArray = new JsonArray();

--- a/src/main/java/com/glencoesoftware/omero/ms/image/region/ImageRegionCtx.java
+++ b/src/main/java/com/glencoesoftware/omero/ms/image/region/ImageRegionCtx.java
@@ -41,7 +41,7 @@ import omeis.providers.re.data.RegionDef;
 import omero.ServerError;
 import omero.constants.projection.ProjectionType;
 
-public class ImageRegionCtx extends OmeroRequestCtx {
+public class ImageRegionCtx extends MicroserviceRequestCtx {
 
     private static final org.slf4j.Logger log =
             LoggerFactory.getLogger(ImageRegionCtx.class);
@@ -166,46 +166,6 @@ public class ImageRegionCtx extends OmeroRequestCtx {
                 "{}, z: {}, t: {}, tile: {}, c: [{}, {}, {}], m: {}, " +
                 "format: {}", imageId, z, t, tile, channels, windows, colors,
                 m, format);
-    }
-
-    private String getCheckedParam(MultiMap params, String key)
-        throws IllegalArgumentException {
-        String value = params.get(key);
-        if (null == value) {
-            throw new IllegalArgumentException("Missing parameter '"
-                + key + "'");
-        }
-        return value;
-    }
-
-    /**
-     * Parse a string to Long and set ast the image ID.
-     * @param imageIdString string
-     */
-    private void getImageIdFromString(String imageIdString)
-        throws IllegalArgumentException{
-        try {
-            imageId = Long.parseLong(imageIdString);
-        } catch (NumberFormatException e) {
-            throw new IllegalArgumentException("Incorrect format for "
-                + "imageid parameter '" + imageIdString + "'");
-        }
-    }
-
-    /**
-     * Parse a string to Integer and return it
-     * @param imageIdString string
-     */
-    private Integer getIntegerFromString(String intString)
-        throws IllegalArgumentException{
-        Integer i = null;
-        try {
-            i = Integer.parseInt(intString);
-        } catch (NumberFormatException e) {
-            throw new IllegalArgumentException("Incorrect format for "
-                + "parameter value '" + intString + "'");
-        }
-        return i;
     }
 
     /**

--- a/src/main/java/com/glencoesoftware/omero/ms/image/region/ImageRegionCtx.java
+++ b/src/main/java/com/glencoesoftware/omero/ms/image/region/ImageRegionCtx.java
@@ -133,7 +133,7 @@ public class ImageRegionCtx extends MicroserviceRequestCtx {
     }
 
     public void assignParams(MultiMap params) throws IllegalArgumentException {
-        getImageIdFromString(getCheckedParam(params, "imageId"));
+        imageId = getImageIdFromString(getCheckedParam(params, "imageId"));
         z = getIntegerFromString(getCheckedParam(params, "theZ"));
         t = getIntegerFromString(getCheckedParam(params, "theT"));
         getTileFromString(params.get("tile"));

--- a/src/main/java/com/glencoesoftware/omero/ms/image/region/ImageRegionCtx.java
+++ b/src/main/java/com/glencoesoftware/omero/ms/image/region/ImageRegionCtx.java
@@ -27,8 +27,6 @@ import java.util.Optional;
 
 import org.slf4j.LoggerFactory;
 
-import com.glencoesoftware.omero.ms.core.OmeroRequestCtx;
-
 import io.vertx.core.MultiMap;
 import io.vertx.core.json.Json;
 import ome.io.nio.PixelBuffer;
@@ -38,7 +36,6 @@ import ome.xml.model.primitives.Color;
 import omeis.providers.re.Renderer;
 import omeis.providers.re.codomain.ReverseIntensityContext;
 import omeis.providers.re.data.RegionDef;
-import omero.ServerError;
 import omero.constants.projection.ProjectionType;
 
 public class ImageRegionCtx extends MicroserviceRequestCtx {

--- a/src/main/java/com/glencoesoftware/omero/ms/image/region/ImageRegionMicroserviceVerticle.java
+++ b/src/main/java/com/glencoesoftware/omero/ms/image/region/ImageRegionMicroserviceVerticle.java
@@ -439,6 +439,11 @@ public class ImageRegionMicroserviceVerticle extends AbstractVerticle {
             int statusCode = 404;
             if (t instanceof ReplyException) {
                 statusCode = ((ReplyException) t).failureCode();
+                response.setStatusMessage(t.getMessage());
+                response.headers().set(
+                        "Content-Length",
+                        String.valueOf(t.getMessage().length()));
+                response.write(t.getMessage());
             }
             if (statusCode < 200 || statusCode > 599) {
                 log.error(

--- a/src/main/java/com/glencoesoftware/omero/ms/image/region/ImageRegionVerticle.java
+++ b/src/main/java/com/glencoesoftware/omero/ms/image/region/ImageRegionVerticle.java
@@ -423,12 +423,6 @@ public class ImageRegionVerticle extends OmeroMsAbstractVerticle {
         try (OmeroRequest request = new OmeroRequest(
                 host, port, histogramCtx.omeroSessionKey))
        {
-           if (families == null) {
-               request.execute(this::updateFamilies);
-           }
-           if (renderingModels == null) {
-               request.execute(this::updateRenderingModels);
-           }
            JsonObject histogramData = request.execute(
                    new HistogramRequestHandler(histogramCtx,
                            pixelsService)::getHistogramJson);

--- a/src/main/java/com/glencoesoftware/omero/ms/image/region/ImageRegionVerticle.java
+++ b/src/main/java/com/glencoesoftware/omero/ms/image/region/ImageRegionVerticle.java
@@ -430,7 +430,7 @@ public class ImageRegionVerticle extends OmeroMsAbstractVerticle {
                                 result.result().body() : null;
                         String histogramDataStr = null;
                         if (histogramDataBytes != null) {
-                            log.info("Histogram in cache!");
+                            log.info("Histogram in cache");
                             histogramDataStr = new String(histogramDataBytes);
                         }
                         HistogramRequestHandler requestHandler =

--- a/src/main/java/com/glencoesoftware/omero/ms/image/region/ImageRegionVerticle.java
+++ b/src/main/java/com/glencoesoftware/omero/ms/image/region/ImageRegionVerticle.java
@@ -468,13 +468,13 @@ public class ImageRegionVerticle extends OmeroMsAbstractVerticle {
                         span.error(e);
                         message.fail(403, v);
                     } catch (IllegalArgumentException e) {
-                        log.debug(
-                                "Illegal argument received while retrieving image region",
+                        log.error(
+                                "Illegal argument received while retrieving histogram",
                                 e);
                         span.error(e);
                         message.fail(400, e.getMessage());
                     } catch (Exception e) {
-                        String v = "Exception while retrieving image region";
+                        String v = "Exception while retrieving histogram";
                         log.error(v, e);
                         span.error(e);
                         message.fail(500, v);

--- a/src/main/java/com/glencoesoftware/omero/ms/image/region/MicroserviceRequestCtx.java
+++ b/src/main/java/com/glencoesoftware/omero/ms/image/region/MicroserviceRequestCtx.java
@@ -41,6 +41,16 @@ abstract class MicroserviceRequestCtx extends OmeroRequestCtx {
         return value;
     }
 
+    protected Boolean getBooleanParameter(MultiMap params, String key) {
+        if (params.get(key) != null) {
+            String booleanString = params.get(key).toLowerCase();
+            if (booleanString.equals("true")) {
+                return true;
+            }
+        }
+        return false;
+    }
+
     /**
      * Parse a string to Long and return.
      * @param imageIdString string

--- a/src/main/java/com/glencoesoftware/omero/ms/image/region/MicroserviceRequestCtx.java
+++ b/src/main/java/com/glencoesoftware/omero/ms/image/region/MicroserviceRequestCtx.java
@@ -12,8 +12,6 @@ import io.vertx.core.MultiMap;
  */
 abstract class MicroserviceRequestCtx extends OmeroRequestCtx {
 
-    Long imageId;
-
     protected String getCheckedParam(MultiMap params, String key)
         throws IllegalArgumentException {
         String value = params.get(key);
@@ -28,10 +26,10 @@ abstract class MicroserviceRequestCtx extends OmeroRequestCtx {
      * Parse a string to Long and set ast the image ID.
      * @param imageIdString string
      */
-    protected void getImageIdFromString(String imageIdString)
+    protected Long getImageIdFromString(String imageIdString)
         throws IllegalArgumentException{
         try {
-            imageId = Long.parseLong(imageIdString);
+            return Long.parseLong(imageIdString);
         } catch (NumberFormatException e) {
             throw new IllegalArgumentException("Incorrect format for "
                 + "imageid parameter '" + imageIdString + "'");

--- a/src/main/java/com/glencoesoftware/omero/ms/image/region/MicroserviceRequestCtx.java
+++ b/src/main/java/com/glencoesoftware/omero/ms/image/region/MicroserviceRequestCtx.java
@@ -1,3 +1,22 @@
+/*
+ * Copyright (C) 2023 Glencoe Software, Inc. All rights reserved.
+ *
+ * This program is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation; either version 2 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License along
+ * with this program; if not, write to the Free Software Foundation, Inc.,
+ * 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
+ */
+
+
 package com.glencoesoftware.omero.ms.image.region;
 
 import com.glencoesoftware.omero.ms.core.OmeroRequestCtx;

--- a/src/main/java/com/glencoesoftware/omero/ms/image/region/MicroserviceRequestCtx.java
+++ b/src/main/java/com/glencoesoftware/omero/ms/image/region/MicroserviceRequestCtx.java
@@ -1,0 +1,56 @@
+package com.glencoesoftware.omero.ms.image.region;
+
+import com.glencoesoftware.omero.ms.core.OmeroRequestCtx;
+
+import io.vertx.core.MultiMap;
+
+/**
+ * Abstract class to allow microservice request contexts to share
+ * helper functions
+ * @author kevin
+ *
+ */
+abstract class MicroserviceRequestCtx extends OmeroRequestCtx {
+
+    Long imageId;
+
+    protected String getCheckedParam(MultiMap params, String key)
+        throws IllegalArgumentException {
+        String value = params.get(key);
+        if (null == value) {
+            throw new IllegalArgumentException("Missing parameter '"
+                + key + "'");
+        }
+        return value;
+    }
+
+    /**
+     * Parse a string to Long and set ast the image ID.
+     * @param imageIdString string
+     */
+    protected void getImageIdFromString(String imageIdString)
+        throws IllegalArgumentException{
+        try {
+            imageId = Long.parseLong(imageIdString);
+        } catch (NumberFormatException e) {
+            throw new IllegalArgumentException("Incorrect format for "
+                + "imageid parameter '" + imageIdString + "'");
+        }
+    }
+
+    /**
+     * Parse a string to Integer and return it
+     * @param imageIdString string
+     */
+    protected Integer getIntegerFromString(String intString)
+        throws IllegalArgumentException{
+        Integer i = null;
+        try {
+            i = Integer.parseInt(intString);
+        } catch (NumberFormatException e) {
+            throw new IllegalArgumentException("Incorrect format for "
+                + "parameter value '" + intString + "'");
+        }
+        return i;
+    }
+}

--- a/src/main/java/com/glencoesoftware/omero/ms/image/region/MicroserviceRequestCtx.java
+++ b/src/main/java/com/glencoesoftware/omero/ms/image/region/MicroserviceRequestCtx.java
@@ -23,7 +23,7 @@ abstract class MicroserviceRequestCtx extends OmeroRequestCtx {
     }
 
     /**
-     * Parse a string to Long and set ast the image ID.
+     * Parse a string to Long and return.
      * @param imageIdString string
      */
     protected Long getImageIdFromString(String imageIdString)
@@ -32,7 +32,7 @@ abstract class MicroserviceRequestCtx extends OmeroRequestCtx {
             return Long.parseLong(imageIdString);
         } catch (NumberFormatException e) {
             throw new IllegalArgumentException("Incorrect format for "
-                + "imageid parameter '" + imageIdString + "'");
+                + "imageId parameter '" + imageIdString + "'");
         }
     }
 

--- a/src/test/java/com/glencoesoftware/omero/ms/image/region/HistogramCtxTest.java
+++ b/src/test/java/com/glencoesoftware/omero/ms/image/region/HistogramCtxTest.java
@@ -37,6 +37,22 @@ public class HistogramCtxTest {
         Assert.assertEquals(Integer.valueOf(4000), ctx.maxPlaneHeight);
     }
 
+    @Test
+    public void testHistogramCorrecttheZtheT() {
+        params.remove("z");
+        params.remove("t");
+        params.add("theZ", "2");
+        params.add("theT", "3");
+        HistogramCtx ctx = new HistogramCtx(params, "abc123");
+        Assert.assertEquals(Long.valueOf(123), ctx.imageId);
+        Assert.assertEquals(Integer.valueOf(1), ctx.c);
+        Assert.assertEquals(Integer.valueOf(2), ctx.z);
+        Assert.assertEquals(Integer.valueOf(3), ctx.t);
+        Assert.assertEquals(Integer.valueOf(10), ctx.bins);
+        Assert.assertEquals(Integer.valueOf(3000), ctx.maxPlaneWidth);
+        Assert.assertEquals(Integer.valueOf(4000), ctx.maxPlaneHeight);
+    }
+
     @Test(expected = IllegalArgumentException.class)
     public void testMissingImageId() {
         params.remove("imageId");

--- a/src/test/java/com/glencoesoftware/omero/ms/image/region/HistogramCtxTest.java
+++ b/src/test/java/com/glencoesoftware/omero/ms/image/region/HistogramCtxTest.java
@@ -1,0 +1,107 @@
+package com.glencoesoftware.omero.ms.image.region;
+
+
+import org.junit.Test;
+
+import io.vertx.core.MultiMap;
+
+import org.junit.Assert;
+import org.junit.Before;
+
+public class HistogramCtxTest {
+
+    private MultiMap params;
+
+    @Before
+    public void setUp() {
+        params = MultiMap.caseInsensitiveMultiMap();
+        params.add("imageId", "123");
+        params.add("theC", "1");
+        params.add("z", "2");
+        params.add("t", "3");
+        params.add("bins", "10");
+        params.add("maxPlaneWidth", "3000");
+        params.add("maxPlaneHeight", "4000");
+        params.add("usePixelsTypeRange", "false");
+    }
+
+    @Test
+    public void testHistogramCorrect() {
+        HistogramCtx ctx = new HistogramCtx(params, "abc123");
+        Assert.assertEquals(Long.valueOf(123), ctx.imageId);
+        Assert.assertEquals(Integer.valueOf(1), ctx.c);
+        Assert.assertEquals(Integer.valueOf(2), ctx.z);
+        Assert.assertEquals(Integer.valueOf(3), ctx.t);
+        Assert.assertEquals(Integer.valueOf(10), ctx.bins);
+        Assert.assertEquals(Integer.valueOf(3000), ctx.maxPlaneWidth);
+        Assert.assertEquals(Integer.valueOf(4000), ctx.maxPlaneHeight);
+    }
+
+    @Test(expected = IllegalArgumentException.class)
+    public void testMissingImageId() {
+        params.remove("imageId");
+        HistogramCtx ctx = new HistogramCtx(params, "abc123");
+    }
+
+    @Test(expected = IllegalArgumentException.class)
+    public void testMissingC() {
+        params.remove("theC");
+        HistogramCtx ctx = new HistogramCtx(params, "abc123");
+    }
+
+    @Test(expected = IllegalArgumentException.class)
+    public void testMissingZ() {
+        params.remove("z");
+        HistogramCtx ctx = new HistogramCtx(params, "abc123");
+    }
+
+    @Test(expected = IllegalArgumentException.class)
+    public void testMissingT() {
+        params.remove("t");
+        HistogramCtx ctx = new HistogramCtx(params, "abc123");
+    }
+
+    @Test
+    public void testMissingBins() {
+        params.remove("bins");
+        HistogramCtx ctx = new HistogramCtx(params, "abc123");
+        Assert.assertEquals(Integer.valueOf(256), ctx.bins);
+    }
+
+    @Test(expected = IllegalArgumentException.class)
+    public void testMissingMaxPlaneWidth() {
+        params.remove("maxPlaneWidth");
+        HistogramCtx ctx = new HistogramCtx(params, "abc123");
+    }
+
+    @Test(expected = IllegalArgumentException.class)
+    public void testMissingMaxPlaneHeight() {
+        params.remove("maxPlaneHeight");
+        HistogramCtx ctx = new HistogramCtx(params, "abc123");
+    }
+
+    @Test
+    public void testUsePixelsTypeRange() {
+        //Check value is "false"
+        HistogramCtx ctx = new HistogramCtx(params, "abc123");
+        Assert.assertEquals(false, ctx.usePixelsTypeRange);
+        //Check value us missing
+        params.remove("usePixelsTypeRange");
+        ctx = new HistogramCtx(params, "abc123");
+        Assert.assertEquals(false, ctx.usePixelsTypeRange);
+        //Check all non-true strings are false
+        params.add("usePixelsTypeRange", "somestring");
+        ctx = new HistogramCtx(params, "abc123");
+        Assert.assertEquals(false, ctx.usePixelsTypeRange);
+        //Check lower case true
+        params.remove("usePixelsTypeRange");
+        params.add("usePixelsTypeRange", "true");
+        ctx = new HistogramCtx(params, "abc123");
+        Assert.assertEquals(true, ctx.usePixelsTypeRange);
+        //Check upper case true
+        params.remove("usePixelsTypeRange");
+        params.add("usePixelsTypeRange", "TRUE");
+        ctx = new HistogramCtx(params, "abc123");
+        Assert.assertEquals(true, ctx.usePixelsTypeRange);
+    }
+}

--- a/src/test/java/com/glencoesoftware/omero/ms/image/region/HistogramRequestHandlerTest.java
+++ b/src/test/java/com/glencoesoftware/omero/ms/image/region/HistogramRequestHandlerTest.java
@@ -1,0 +1,100 @@
+package com.glencoesoftware.omero.ms.image.region;
+
+
+import org.junit.Before;
+import org.junit.Test;
+
+import java.nio.ByteBuffer;
+
+import io.vertx.core.MultiMap;
+import io.vertx.core.http.CaseInsensitiveHeaders;
+import io.vertx.core.json.JsonArray;
+import org.junit.Assert;
+import ome.model.enums.PixelsType;
+import ome.util.PixelData;
+
+public class HistogramRequestHandlerTest {
+
+    private HistogramCtx histogramCtx;
+
+    private HistogramRequestHandler requestHandler;
+
+    @Before
+    public void setUp() {
+        MultiMap params = new CaseInsensitiveHeaders();
+
+        params.add("imageId", "1");
+        params.add("theC", "0");
+        params.add("z", "0");
+        params.add("t", "0");
+        params.add("maxPlaneWidth", "2048");
+        params.add("maxPlaneHeight", "2048");
+
+        histogramCtx = new HistogramCtx(params, "");
+        requestHandler = new HistogramRequestHandler(histogramCtx, null);
+    }
+
+    @Test
+    public void testHistogramData() {
+        ByteBuffer bb = ByteBuffer.allocate(4);
+        bb.put(new byte[] {1,2,3,4});
+        PixelData pd = new PixelData(PixelsType.VALUE_UINT8, bb);
+        int imgWidth = 256;
+        int imgHeight = 512;
+        double[] minMax = new double[] {0, 4};
+        histogramCtx.bins = 4;
+        JsonArray testData = requestHandler.getHistogramData(pd,
+                minMax, imgWidth, imgHeight);
+        Assert.assertEquals(testData.size(), 4);
+        Assert.assertEquals(testData.getValue(0), 1);
+        Assert.assertEquals(testData.getValue(1), 1);
+        Assert.assertEquals(testData.getValue(2), 1);
+        Assert.assertEquals(testData.getValue(3), 1);
+    }
+
+    @Test(expected=IllegalArgumentException.class)
+    public void testValGreaterThanMax() {
+        ByteBuffer bb = ByteBuffer.allocate(4);
+        bb.put(new byte[] {1,2,3,4});
+        PixelData pd = new PixelData(PixelsType.VALUE_UINT8, bb);
+        int imgWidth = 256;
+        int imgHeight = 512;
+        double[] minMax = new double[] {0, 3};
+        histogramCtx.bins = 4;
+        JsonArray testData = requestHandler.getHistogramData(pd,
+                minMax, imgWidth, imgHeight);
+    }
+
+    @Test(expected=IllegalArgumentException.class)
+    public void testValLessThanMin() {
+        ByteBuffer bb = ByteBuffer.allocate(4);
+        bb.put(new byte[] {1,2,3,4});
+        PixelData pd = new PixelData(PixelsType.VALUE_UINT8, bb);
+        int imgWidth = 256;
+        int imgHeight = 512;
+        double[] minMax = new double[] {2, 4};
+        histogramCtx.bins = 4;
+        JsonArray testData = requestHandler.getHistogramData(pd,
+                minMax, imgWidth, imgHeight);
+    }
+
+    @Test
+    public void testMoreBinsThanValues() {
+        ByteBuffer bb = ByteBuffer.allocate(3);
+        bb.put(new byte[] {0,1,3});
+        PixelData pd = new PixelData(PixelsType.VALUE_UINT8, bb);
+        int imgWidth = 256;
+        int imgHeight = 512;
+        double[] minMax = new double[] {0, 3};
+        histogramCtx.bins = 5;
+        JsonArray testData = requestHandler.getHistogramData(pd,
+                minMax, imgWidth, imgHeight);
+        Assert.assertEquals(5, testData.size());
+        Assert.assertEquals(1, (int) testData.getInteger(0));
+        Assert.assertEquals(0, (int) testData.getInteger(1));
+        Assert.assertEquals(1, (int) testData.getInteger(2));
+        Assert.assertEquals(0, (int) testData.getInteger(3));
+        Assert.assertEquals(1, (int) testData.getInteger(4));
+    }
+
+}

--- a/src/test/java/com/glencoesoftware/omero/ms/image/region/HistogramRequestHandlerTest.java
+++ b/src/test/java/com/glencoesoftware/omero/ms/image/region/HistogramRequestHandlerTest.java
@@ -97,4 +97,41 @@ public class HistogramRequestHandlerTest {
         Assert.assertEquals(1, (int) testData.getInteger(4));
     }
 
+    @Test
+    public void testRangeLargerThanData() {
+        ByteBuffer bb = ByteBuffer.allocate(3);
+        bb.put(new byte[] {3,4,5});
+        PixelData pd = new PixelData(PixelsType.VALUE_UINT8, bb);
+        int imgWidth = 256;
+        int imgHeight = 512;
+        double[] minMax = new double[] {0, 9};
+        histogramCtx.bins = 5;
+        JsonArray testData = requestHandler.getHistogramData(pd,
+                minMax, imgWidth, imgHeight);
+        Assert.assertEquals(5, testData.size());
+        Assert.assertEquals(0, (int) testData.getInteger(0));
+        Assert.assertEquals(1, (int) testData.getInteger(1)); //3
+        Assert.assertEquals(2, (int) testData.getInteger(2)); //4, 5
+        Assert.assertEquals(0, (int) testData.getInteger(3));
+        Assert.assertEquals(0, (int) testData.getInteger(4));
+    }
+
+    @Test
+    public void testPixelDataLargerThanMaxPlaneSize() {
+        ByteBuffer bb = ByteBuffer.allocate(4);
+        bb.put(new byte[] {0,1,2,3});
+        PixelData pd = new PixelData(PixelsType.VALUE_UINT8, bb);
+        int imgWidth = 1;
+        int imgHeight = 1;
+        double[] minMax = new double[] {0, 3};
+        histogramCtx.bins = 2;
+        JsonArray testData = requestHandler.getHistogramData(pd,
+                minMax, imgWidth, imgHeight);
+        Assert.assertEquals(2, testData.size());
+        //0 is the only value that fits in the 1x1 region
+        //specified by
+        Assert.assertEquals(2, (int) testData.getInteger(0)); //0,1
+        Assert.assertEquals(2, (int) testData.getInteger(1)); //2.3
+    }
+
 }

--- a/src/test/java/com/glencoesoftware/omero/ms/image/region/HistogramRequestHandlerTest.java
+++ b/src/test/java/com/glencoesoftware/omero/ms/image/region/HistogramRequestHandlerTest.java
@@ -9,6 +9,8 @@ import java.nio.ByteBuffer;
 import io.vertx.core.MultiMap;
 import io.vertx.core.http.CaseInsensitiveHeaders;
 import io.vertx.core.json.JsonArray;
+import io.vertx.core.json.JsonObject;
+
 import org.junit.Assert;
 import ome.model.enums.PixelsType;
 import ome.util.PixelData;
@@ -39,12 +41,10 @@ public class HistogramRequestHandlerTest {
         ByteBuffer bb = ByteBuffer.allocate(4);
         bb.put(new byte[] {1,2,3,4});
         PixelData pd = new PixelData(PixelsType.VALUE_UINT8, bb);
-        int imgWidth = 256;
-        int imgHeight = 512;
         double[] minMax = new double[] {0, 4};
         histogramCtx.bins = 4;
         JsonArray testData = requestHandler.getHistogramData(pd,
-                minMax);
+                minMax).getJsonArray(HistogramRequestHandler.HISTOGRAM_DATA_KEY);
         Assert.assertEquals(testData.size(), 4);
         Assert.assertEquals(testData.getValue(0), 1);
         Assert.assertEquals(testData.getValue(1), 1);
@@ -52,30 +52,34 @@ public class HistogramRequestHandlerTest {
         Assert.assertEquals(testData.getValue(3), 1);
     }
 
-    @Test(expected=IllegalArgumentException.class)
+    @Test
     public void testValGreaterThanMax() {
         ByteBuffer bb = ByteBuffer.allocate(4);
         bb.put(new byte[] {1,2,3,4});
         PixelData pd = new PixelData(PixelsType.VALUE_UINT8, bb);
-        int imgWidth = 256;
-        int imgHeight = 512;
         double[] minMax = new double[] {0, 3};
         histogramCtx.bins = 4;
-        JsonArray testData = requestHandler.getHistogramData(pd,
+        JsonObject testData = requestHandler.getHistogramData(pd,
                 minMax);
-    }
+        Assert.assertEquals(testData.getInteger(
+                HistogramRequestHandler.LEFT_OUTLIER_COUNT_KEY).intValue(), 0);
+        Assert.assertEquals(testData.getInteger(
+                HistogramRequestHandler.RIGHT_OUTLIER_COUNT_KEY).intValue(), 1);
+        }
 
-    @Test(expected=IllegalArgumentException.class)
+    @Test
     public void testValLessThanMin() {
         ByteBuffer bb = ByteBuffer.allocate(4);
         bb.put(new byte[] {1,2,3,4});
         PixelData pd = new PixelData(PixelsType.VALUE_UINT8, bb);
-        int imgWidth = 256;
-        int imgHeight = 512;
         double[] minMax = new double[] {2, 4};
         histogramCtx.bins = 4;
-        JsonArray testData = requestHandler.getHistogramData(pd,
+        JsonObject testData = requestHandler.getHistogramData(pd,
                 minMax);
+        Assert.assertEquals(testData.getInteger(
+                HistogramRequestHandler.LEFT_OUTLIER_COUNT_KEY).intValue(), 1);
+        Assert.assertEquals(testData.getInteger(
+                HistogramRequestHandler.RIGHT_OUTLIER_COUNT_KEY).intValue(), 0);
     }
 
     @Test
@@ -83,12 +87,10 @@ public class HistogramRequestHandlerTest {
         ByteBuffer bb = ByteBuffer.allocate(3);
         bb.put(new byte[] {0,1,3});
         PixelData pd = new PixelData(PixelsType.VALUE_UINT8, bb);
-        int imgWidth = 256;
-        int imgHeight = 512;
         double[] minMax = new double[] {0, 3};
         histogramCtx.bins = 5;
         JsonArray testData = requestHandler.getHistogramData(pd,
-                minMax);
+                minMax).getJsonArray(HistogramRequestHandler.HISTOGRAM_DATA_KEY);
         Assert.assertEquals(5, testData.size());
         Assert.assertEquals(1, (int) testData.getInteger(0));
         Assert.assertEquals(0, (int) testData.getInteger(1));
@@ -102,12 +104,10 @@ public class HistogramRequestHandlerTest {
         ByteBuffer bb = ByteBuffer.allocate(3);
         bb.put(new byte[] {3,4,5});
         PixelData pd = new PixelData(PixelsType.VALUE_UINT8, bb);
-        int imgWidth = 256;
-        int imgHeight = 512;
         double[] minMax = new double[] {0, 9};
         histogramCtx.bins = 5;
         JsonArray testData = requestHandler.getHistogramData(pd,
-                minMax);
+                minMax).getJsonArray(HistogramRequestHandler.HISTOGRAM_DATA_KEY);
         Assert.assertEquals(5, testData.size());
         Assert.assertEquals(0, (int) testData.getInteger(0));
         Assert.assertEquals(1, (int) testData.getInteger(1)); //3
@@ -121,12 +121,10 @@ public class HistogramRequestHandlerTest {
         ByteBuffer bb = ByteBuffer.allocate(4);
         bb.put(new byte[] {0,1,2,3});
         PixelData pd = new PixelData(PixelsType.VALUE_UINT8, bb);
-        int imgWidth = 1;
-        int imgHeight = 1;
         double[] minMax = new double[] {0, 3};
         histogramCtx.bins = 2;
         JsonArray testData = requestHandler.getHistogramData(pd,
-                minMax);
+                minMax).getJsonArray(HistogramRequestHandler.HISTOGRAM_DATA_KEY);
         Assert.assertEquals(2, testData.size());
         Assert.assertEquals(2, (int) testData.getInteger(0)); //0,1
         Assert.assertEquals(2, (int) testData.getInteger(1)); //2.3

--- a/src/test/java/com/glencoesoftware/omero/ms/image/region/HistogramRequestHandlerTest.java
+++ b/src/test/java/com/glencoesoftware/omero/ms/image/region/HistogramRequestHandlerTest.java
@@ -44,7 +44,7 @@ public class HistogramRequestHandlerTest {
         double[] minMax = new double[] {0, 4};
         histogramCtx.bins = 4;
         JsonArray testData = requestHandler.getHistogramData(pd,
-                minMax, imgWidth, imgHeight);
+                minMax);
         Assert.assertEquals(testData.size(), 4);
         Assert.assertEquals(testData.getValue(0), 1);
         Assert.assertEquals(testData.getValue(1), 1);
@@ -62,7 +62,7 @@ public class HistogramRequestHandlerTest {
         double[] minMax = new double[] {0, 3};
         histogramCtx.bins = 4;
         JsonArray testData = requestHandler.getHistogramData(pd,
-                minMax, imgWidth, imgHeight);
+                minMax);
     }
 
     @Test(expected=IllegalArgumentException.class)
@@ -75,7 +75,7 @@ public class HistogramRequestHandlerTest {
         double[] minMax = new double[] {2, 4};
         histogramCtx.bins = 4;
         JsonArray testData = requestHandler.getHistogramData(pd,
-                minMax, imgWidth, imgHeight);
+                minMax);
     }
 
     @Test
@@ -88,7 +88,7 @@ public class HistogramRequestHandlerTest {
         double[] minMax = new double[] {0, 3};
         histogramCtx.bins = 5;
         JsonArray testData = requestHandler.getHistogramData(pd,
-                minMax, imgWidth, imgHeight);
+                minMax);
         Assert.assertEquals(5, testData.size());
         Assert.assertEquals(1, (int) testData.getInteger(0));
         Assert.assertEquals(0, (int) testData.getInteger(1));
@@ -107,7 +107,7 @@ public class HistogramRequestHandlerTest {
         double[] minMax = new double[] {0, 9};
         histogramCtx.bins = 5;
         JsonArray testData = requestHandler.getHistogramData(pd,
-                minMax, imgWidth, imgHeight);
+                minMax);
         Assert.assertEquals(5, testData.size());
         Assert.assertEquals(0, (int) testData.getInteger(0));
         Assert.assertEquals(1, (int) testData.getInteger(1)); //3
@@ -126,10 +126,8 @@ public class HistogramRequestHandlerTest {
         double[] minMax = new double[] {0, 3};
         histogramCtx.bins = 2;
         JsonArray testData = requestHandler.getHistogramData(pd,
-                minMax, imgWidth, imgHeight);
+                minMax);
         Assert.assertEquals(2, testData.size());
-        //0 is the only value that fits in the 1x1 region
-        //specified by
         Assert.assertEquals(2, (int) testData.getInteger(0)); //0,1
         Assert.assertEquals(2, (int) testData.getInteger(1)); //2.3
     }


### PR DESCRIPTION
Add an endpoint `/histogram_json` to match the omero-web endpoint.
See https://github.com/ome/omero-web/blob/master/omeroweb/webgateway/urls.py#L457
and
https://github.com/ome/omero-web/blob/master/omeroweb/webgateway/views.py#L2831) 

## Testing
Endpoint should work exactly like the omero-web endpoint for sufficiently small images (smaller than max plane width x max plane height). For larger images the omero-web endpoint will return an error but this endpoint should function.