### PR TITLE
Explicitly name the CSV as image-list-${DATESTR}.csv

### DIFF
--- a/src/dist/regen-memo-files.sh
+++ b/src/dist/regen-memo-files.sh
@@ -186,7 +186,7 @@ if [ -s "${FULL_CSV}" ]; then
     sleep 5s
   fi
   mkdir -p rslt.${DATESTR}
-  mv -v ${FULL_CSV} rslt.${DATESTR}/
+  mv -v ${FULL_CSV} rslt.${DATESTR}/image-list-${DATESTR}.csv
   run_split_parallel_os_dep
 else
   echo "No images to process"


### PR DESCRIPTION
The memo regeneration status script assumes the CSV timestamp suffix is consistent with the results directory.
In case a custom CSV is supplied via `--csv CSV`, this allows the output of this script to remain compatible with the status script.

Can be tested by running a simple workflow like

```
psql -f memo_regenerator.sql omero > images.csv
shuf images.csv > images2.csv
./regen-memo-files.sh --csv images2.csv
```
and inspecting the status of the regeneration
```
./memofile-regen-status.sh rslt.<timestamp>/
```