### PR TITLE
Histogram endpoint: fix bin assignment for non integer and add tests for all supported pixel types

### DIFF
--- a/src/main/java/com/glencoesoftware/omero/ms/image/region/HistogramRequestHandler.java
+++ b/src/main/java/com/glencoesoftware/omero/ms/image/region/HistogramRequestHandler.java
@@ -126,24 +126,22 @@ public class HistogramRequestHandler {
         double min = minMax[0];
         double max = minMax[1];
 
-        double range = max - min + 1;
+        double range = max - min;
         double binRange = range / histogramCtx.bins;
         int leftOutlierCount = 0;
         int rightOutlierCount = 0;
         for (int i = 0; i < pd.size(); i++) {
-            int bin = (int) ((pd.getPixelValue(i) - min) / binRange);
-            // if there are more bins than values (binRange < 1) the bin will be offset by -1.
-            // e.g. min=0.0, max=127.0, binCount=256: a pixel with max value 127.0 would go
-            // into bin 254 (expected: 255). Therefore increment by one for these cases.
-            if (bin > 0 && binRange < 1)
-                bin++;
-
-            if (bin >= 0 && bin < histogramCtx.bins) {
-                counts[bin]++;
-            } else if (pd.getPixelValue(i) < min) {
+            if (pd.getPixelValue(i) < min) {
                 leftOutlierCount++;
             } else if (pd.getPixelValue(i) > max) {
                 rightOutlierCount++;
+            } else {
+                int bin = (int) ((pd.getPixelValue(i) - min) / binRange);
+                // Handle values exactly at the last edge
+                if (bin == histogramCtx.bins) {
+                    bin--;
+                }
+                counts[bin]++;
             }
         }
         JsonArray histogramArray = new JsonArray();

--- a/src/test/java/com/glencoesoftware/omero/ms/image/region/HistogramRequestHandlerTest.java
+++ b/src/test/java/com/glencoesoftware/omero/ms/image/region/HistogramRequestHandlerTest.java
@@ -43,13 +43,18 @@ public class HistogramRequestHandlerTest {
         PixelData pd = new PixelData(PixelsType.VALUE_UINT8, bb);
         double[] minMax = new double[] {0, 4};
         histogramCtx.bins = 4;
-        JsonArray testData = requestHandler.getHistogramData(pd,
-                minMax).getJsonArray(HistogramRequestHandler.HISTOGRAM_DATA_KEY);
+        JsonObject histogramData = requestHandler.getHistogramData(pd, minMax);
+        JsonArray testData = histogramData.getJsonArray(
+            HistogramRequestHandler.HISTOGRAM_DATA_KEY);
         Assert.assertEquals(testData.size(), 4);
         Assert.assertEquals(testData.getValue(0), 1);
         Assert.assertEquals(testData.getValue(1), 1);
         Assert.assertEquals(testData.getValue(2), 1);
         Assert.assertEquals(testData.getValue(3), 1);
+        Assert.assertEquals(histogramData.getInteger(
+                HistogramRequestHandler.LEFT_OUTLIER_COUNT_KEY).intValue(), 0);
+        Assert.assertEquals(histogramData.getInteger(
+                HistogramRequestHandler.RIGHT_OUTLIER_COUNT_KEY).intValue(), 0);
     }
 
     @Test
@@ -59,11 +64,17 @@ public class HistogramRequestHandlerTest {
         PixelData pd = new PixelData(PixelsType.VALUE_UINT8, bb);
         double[] minMax = new double[] {0, 3};
         histogramCtx.bins = 4;
-        JsonObject testData = requestHandler.getHistogramData(pd,
-                minMax);
-        Assert.assertEquals(testData.getInteger(
+        JsonObject histogramData = requestHandler.getHistogramData(pd, minMax);
+        JsonArray testData = histogramData.getJsonArray(
+            HistogramRequestHandler.HISTOGRAM_DATA_KEY);
+        Assert.assertEquals(testData.size(), 4);
+        Assert.assertEquals(testData.getValue(0), 0);
+        Assert.assertEquals(testData.getValue(1), 1);
+        Assert.assertEquals(testData.getValue(2), 1);
+        Assert.assertEquals(testData.getValue(3), 1);
+        Assert.assertEquals(histogramData.getInteger(
                 HistogramRequestHandler.LEFT_OUTLIER_COUNT_KEY).intValue(), 0);
-        Assert.assertEquals(testData.getInteger(
+        Assert.assertEquals(histogramData.getInteger(
                 HistogramRequestHandler.RIGHT_OUTLIER_COUNT_KEY).intValue(), 1);
         }
 
@@ -74,11 +85,17 @@ public class HistogramRequestHandlerTest {
         PixelData pd = new PixelData(PixelsType.VALUE_UINT8, bb);
         double[] minMax = new double[] {2, 4};
         histogramCtx.bins = 4;
-        JsonObject testData = requestHandler.getHistogramData(pd,
-                minMax);
-        Assert.assertEquals(testData.getInteger(
+        JsonObject histogramData = requestHandler.getHistogramData(pd, minMax);
+        JsonArray testData = histogramData.getJsonArray(
+            HistogramRequestHandler.HISTOGRAM_DATA_KEY);
+        Assert.assertEquals(testData.size(), 4);
+        Assert.assertEquals(testData.getValue(0), 1);
+        Assert.assertEquals(testData.getValue(1), 0);
+        Assert.assertEquals(testData.getValue(2), 1);
+        Assert.assertEquals(testData.getValue(3), 1);
+        Assert.assertEquals(histogramData.getInteger(
                 HistogramRequestHandler.LEFT_OUTLIER_COUNT_KEY).intValue(), 1);
-        Assert.assertEquals(testData.getInteger(
+        Assert.assertEquals(histogramData.getInteger(
                 HistogramRequestHandler.RIGHT_OUTLIER_COUNT_KEY).intValue(), 0);
     }
 
@@ -89,14 +106,19 @@ public class HistogramRequestHandlerTest {
         PixelData pd = new PixelData(PixelsType.VALUE_UINT8, bb);
         double[] minMax = new double[] {0, 3};
         histogramCtx.bins = 5;
-        JsonArray testData = requestHandler.getHistogramData(pd,
-                minMax).getJsonArray(HistogramRequestHandler.HISTOGRAM_DATA_KEY);
+        JsonObject histogramData = requestHandler.getHistogramData(pd, minMax);
+        JsonArray testData = histogramData.getJsonArray(
+            HistogramRequestHandler.HISTOGRAM_DATA_KEY);
         Assert.assertEquals(5, testData.size());
         Assert.assertEquals(1, (int) testData.getInteger(0));
         Assert.assertEquals(0, (int) testData.getInteger(1));
         Assert.assertEquals(1, (int) testData.getInteger(2));
         Assert.assertEquals(0, (int) testData.getInteger(3));
         Assert.assertEquals(1, (int) testData.getInteger(4));
+        Assert.assertEquals(histogramData.getInteger(
+                HistogramRequestHandler.LEFT_OUTLIER_COUNT_KEY).intValue(), 0);
+        Assert.assertEquals(histogramData.getInteger(
+                HistogramRequestHandler.RIGHT_OUTLIER_COUNT_KEY).intValue(), 0);
     }
 
     @Test
@@ -106,14 +128,19 @@ public class HistogramRequestHandlerTest {
         PixelData pd = new PixelData(PixelsType.VALUE_UINT8, bb);
         double[] minMax = new double[] {0, 9};
         histogramCtx.bins = 5;
-        JsonArray testData = requestHandler.getHistogramData(pd,
-                minMax).getJsonArray(HistogramRequestHandler.HISTOGRAM_DATA_KEY);
+        JsonObject histogramData = requestHandler.getHistogramData(pd, minMax);
+        JsonArray testData = histogramData.getJsonArray(
+            HistogramRequestHandler.HISTOGRAM_DATA_KEY);
         Assert.assertEquals(5, testData.size());
         Assert.assertEquals(0, (int) testData.getInteger(0));
         Assert.assertEquals(1, (int) testData.getInteger(1)); //3
         Assert.assertEquals(2, (int) testData.getInteger(2)); //4, 5
         Assert.assertEquals(0, (int) testData.getInteger(3));
         Assert.assertEquals(0, (int) testData.getInteger(4));
+        Assert.assertEquals(histogramData.getInteger(
+                HistogramRequestHandler.LEFT_OUTLIER_COUNT_KEY).intValue(), 0);
+        Assert.assertEquals(histogramData.getInteger(
+                HistogramRequestHandler.RIGHT_OUTLIER_COUNT_KEY).intValue(), 0);
     }
 
     @Test
@@ -123,11 +150,15 @@ public class HistogramRequestHandlerTest {
         PixelData pd = new PixelData(PixelsType.VALUE_UINT8, bb);
         double[] minMax = new double[] {0, 3};
         histogramCtx.bins = 2;
-        JsonArray testData = requestHandler.getHistogramData(pd,
-                minMax).getJsonArray(HistogramRequestHandler.HISTOGRAM_DATA_KEY);
+        JsonObject histogramData = requestHandler.getHistogramData(pd, minMax);
+        JsonArray testData = histogramData.getJsonArray(
+            HistogramRequestHandler.HISTOGRAM_DATA_KEY);
         Assert.assertEquals(2, testData.size());
         Assert.assertEquals(2, (int) testData.getInteger(0)); //0,1
         Assert.assertEquals(2, (int) testData.getInteger(1)); //2.3
+        Assert.assertEquals(histogramData.getInteger(
+                HistogramRequestHandler.LEFT_OUTLIER_COUNT_KEY).intValue(), 0);
+        Assert.assertEquals(histogramData.getInteger(
+                HistogramRequestHandler.RIGHT_OUTLIER_COUNT_KEY).intValue(), 0);
     }
-
 }

--- a/src/test/java/com/glencoesoftware/omero/ms/image/region/HistogramRequestHandlerTest.java
+++ b/src/test/java/com/glencoesoftware/omero/ms/image/region/HistogramRequestHandlerTest.java
@@ -47,10 +47,10 @@ public class HistogramRequestHandlerTest {
         JsonArray testData = histogramData.getJsonArray(
             HistogramRequestHandler.HISTOGRAM_DATA_KEY);
         Assert.assertEquals(testData.size(), 4);
-        Assert.assertEquals(testData.getValue(0), 1);
+        Assert.assertEquals(testData.getValue(0), 0);
         Assert.assertEquals(testData.getValue(1), 1);
         Assert.assertEquals(testData.getValue(2), 1);
-        Assert.assertEquals(testData.getValue(3), 1);
+        Assert.assertEquals(testData.getValue(3), 2);
         Assert.assertEquals(histogramData.getInteger(
                 HistogramRequestHandler.LEFT_OUTLIER_COUNT_KEY).intValue(), 0);
         Assert.assertEquals(histogramData.getInteger(
@@ -111,8 +111,8 @@ public class HistogramRequestHandlerTest {
             HistogramRequestHandler.HISTOGRAM_DATA_KEY);
         Assert.assertEquals(5, testData.size());
         Assert.assertEquals(1, (int) testData.getInteger(0));
-        Assert.assertEquals(0, (int) testData.getInteger(1));
-        Assert.assertEquals(1, (int) testData.getInteger(2));
+        Assert.assertEquals(1, (int) testData.getInteger(1));
+        Assert.assertEquals(0, (int) testData.getInteger(2));
         Assert.assertEquals(0, (int) testData.getInteger(3));
         Assert.assertEquals(1, (int) testData.getInteger(4));
         Assert.assertEquals(histogramData.getInteger(
@@ -184,8 +184,8 @@ public class HistogramRequestHandlerTest {
         Assert.assertEquals(testData.size(), 5);
         Assert.assertEquals(testData.getValue(0), 2);
         Assert.assertEquals(testData.getValue(1), 1);
-        Assert.assertEquals(testData.getValue(2), 4);
-        Assert.assertEquals(testData.getValue(3), 2);
+        Assert.assertEquals(testData.getValue(2), 3);
+        Assert.assertEquals(testData.getValue(3), 3);
         Assert.assertEquals(testData.getValue(4), 1);
         Assert.assertEquals(histogramData.getInteger(
                 HistogramRequestHandler.LEFT_OUTLIER_COUNT_KEY).intValue(), 0);

--- a/src/test/java/com/glencoesoftware/omero/ms/image/region/HistogramRequestHandlerTest.java
+++ b/src/test/java/com/glencoesoftware/omero/ms/image/region/HistogramRequestHandlerTest.java
@@ -161,4 +161,252 @@ public class HistogramRequestHandlerTest {
         Assert.assertEquals(histogramData.getInteger(
                 HistogramRequestHandler.RIGHT_OUTLIER_COUNT_KEY).intValue(), 0);
     }
+
+    @Test
+    public void testUINT8() {
+        ByteBuffer bb = ByteBuffer.allocate(10);
+        bb.put((byte) (175 & 0xff));
+        bb.put((byte) (153 & 0xff));
+        bb.put((byte) (63 & 0xff));
+        bb.put((byte) (173 & 0xff));
+        bb.put((byte) (143 & 0xff));
+        bb.put((byte) (218 & 0xff));
+        bb.put((byte) (145 & 0xff));
+        bb.put((byte) (39 & 0xff));
+        bb.put((byte) (138 & 0xff));
+        bb.put((byte) (3 & 0xff));
+        PixelData pd = new PixelData(PixelsType.VALUE_UINT8, bb);
+        double[] minMax = new double[] {0, 255};
+        histogramCtx.bins = 5;
+        JsonObject histogramData = requestHandler.getHistogramData(pd, minMax);
+        JsonArray testData = histogramData.getJsonArray(
+            HistogramRequestHandler.HISTOGRAM_DATA_KEY);
+        Assert.assertEquals(testData.size(), 5);
+        Assert.assertEquals(testData.getValue(0), 2);
+        Assert.assertEquals(testData.getValue(1), 1);
+        Assert.assertEquals(testData.getValue(2), 4);
+        Assert.assertEquals(testData.getValue(3), 2);
+        Assert.assertEquals(testData.getValue(4), 1);
+        Assert.assertEquals(histogramData.getInteger(
+                HistogramRequestHandler.LEFT_OUTLIER_COUNT_KEY).intValue(), 0);
+        Assert.assertEquals(histogramData.getInteger(
+                HistogramRequestHandler.RIGHT_OUTLIER_COUNT_KEY).intValue(), 0);
+    }
+
+    @Test
+    public void testINT8() {
+        ByteBuffer bb = ByteBuffer.allocate(10);
+        bb.put((byte) 101);
+        bb.put((byte) -50);
+        bb.put((byte) 82);
+        bb.put((byte) 40);
+        bb.put((byte) -68);
+        bb.put((byte) -18);
+        bb.put((byte) -92);
+        bb.put((byte) -95);
+        bb.put((byte) 48);
+        bb.put((byte) -78);
+        PixelData pd = new PixelData(PixelsType.VALUE_INT8, bb);
+        double[] minMax = new double[] {-128, 127};
+        histogramCtx.bins = 5;
+        JsonObject histogramData = requestHandler.getHistogramData(pd, minMax);
+        JsonArray testData = histogramData.getJsonArray(
+            HistogramRequestHandler.HISTOGRAM_DATA_KEY);
+        Assert.assertEquals(testData.size(), 5);
+        Assert.assertEquals(testData.getValue(0), 3);
+        Assert.assertEquals(testData.getValue(1), 2);
+        Assert.assertEquals(testData.getValue(2), 1);
+        Assert.assertEquals(testData.getValue(3), 2);
+        Assert.assertEquals(testData.getValue(4), 2);
+        Assert.assertEquals(histogramData.getInteger(
+                HistogramRequestHandler.LEFT_OUTLIER_COUNT_KEY).intValue(), 0);
+        Assert.assertEquals(histogramData.getInteger(
+                HistogramRequestHandler.RIGHT_OUTLIER_COUNT_KEY).intValue(), 0);
+    }
+
+    @Test
+    public void testUINT16() {
+        ByteBuffer bb = ByteBuffer.allocate(20);
+        bb.putShort((short) (21533 & 0xffff));
+        bb.putShort((short) (38752 & 0xffff));
+        bb.putShort((short) (36269 & 0xffff));
+        bb.putShort((short) (2760 & 0xffff));
+        bb.putShort((short) (1425 & 0xffff));
+        bb.putShort((short) (14880 & 0xffff));
+        bb.putShort((short) (34827 & 0xffff));
+        bb.putShort((short) (11986 & 0xffff));
+        bb.putShort((short) (11077 & 0xffff));
+        bb.putShort((short) (46156 & 0xffff));
+        PixelData pd = new PixelData(PixelsType.VALUE_UINT16, bb);
+        double[] minMax = new double[] {0, 65535};
+        histogramCtx.bins = 5;
+        JsonObject histogramData = requestHandler.getHistogramData(pd, minMax);
+        JsonArray testData = histogramData.getJsonArray(
+            HistogramRequestHandler.HISTOGRAM_DATA_KEY);
+        Assert.assertEquals(testData.size(), 5);
+        Assert.assertEquals(testData.getValue(0), 4);
+        Assert.assertEquals(testData.getValue(1), 2);
+        Assert.assertEquals(testData.getValue(2), 3);
+        Assert.assertEquals(testData.getValue(3), 1);
+        Assert.assertEquals(testData.getValue(4), 0);
+        Assert.assertEquals(histogramData.getInteger(
+                HistogramRequestHandler.LEFT_OUTLIER_COUNT_KEY).intValue(), 0);
+        Assert.assertEquals(histogramData.getInteger(
+                HistogramRequestHandler.RIGHT_OUTLIER_COUNT_KEY).intValue(), 0);
+    }
+
+    @Test
+    public void testINT16() {
+        ByteBuffer bb = ByteBuffer.allocate(20);
+        bb.putShort((short) -19497);
+        bb.putShort((short) -11285);
+        bb.putShort((short) 1187);
+        bb.putShort((short) -17219);
+        bb.putShort((short) 26833);
+        bb.putShort((short) 28521);
+        bb.putShort((short) -31711);
+        bb.putShort((short) -21571);
+        bb.putShort((short) -12075);
+        bb.putShort((short) 6841);
+        PixelData pd = new PixelData(PixelsType.VALUE_INT16, bb);
+        double[] minMax = new double[] {-32768, 32767};
+        histogramCtx.bins = 5;
+        JsonObject histogramData = requestHandler.getHistogramData(pd, minMax);
+        JsonArray testData = histogramData.getJsonArray(
+            HistogramRequestHandler.HISTOGRAM_DATA_KEY);
+        Assert.assertEquals(testData.size(), 5);
+        Assert.assertEquals(testData.getValue(0), 2);
+        Assert.assertEquals(testData.getValue(1), 4);
+        Assert.assertEquals(testData.getValue(2), 1);
+        Assert.assertEquals(testData.getValue(3), 1);
+        Assert.assertEquals(testData.getValue(4), 2);
+        Assert.assertEquals(histogramData.getInteger(
+                HistogramRequestHandler.LEFT_OUTLIER_COUNT_KEY).intValue(), 0);
+        Assert.assertEquals(histogramData.getInteger(
+                HistogramRequestHandler.RIGHT_OUTLIER_COUNT_KEY).intValue(), 0);
+    }
+
+    @Test
+    public void testUINT32() {
+        ByteBuffer bb = ByteBuffer.allocate(40);
+        bb.putInt((int) (1039053181L & 0xffffffffL));
+        bb.putInt((int) (1966804319L & 0xffffffffL));
+        bb.putInt((int) (3513814796L & 0xffffffffL));
+        bb.putInt((int) (642532262L & 0xffffffffL));
+        bb.putInt((int) (3411013609L & 0xffffffffL));
+        bb.putInt((int) (433606742L & 0xffffffffL));
+        bb.putInt((int) (2289077882L & 0xffffffffL));
+        bb.putInt((int) (4100655705L & 0xffffffffL));
+        bb.putInt((int) (3585211196L & 0xffffffffL));
+        bb.putInt((int) (1356288417L & 0xffffffffL));
+        PixelData pd = new PixelData(PixelsType.VALUE_UINT32, bb);
+        double[] minMax = new double[] {0, 4294967295L};
+        histogramCtx.bins = 5;
+        JsonObject histogramData = requestHandler.getHistogramData(pd, minMax);
+        JsonArray testData = histogramData.getJsonArray(
+            HistogramRequestHandler.HISTOGRAM_DATA_KEY);
+        Assert.assertEquals(testData.size(), 5);
+        Assert.assertEquals(testData.getValue(0), 2);
+        Assert.assertEquals(testData.getValue(1), 2);
+        Assert.assertEquals(testData.getValue(2), 2);
+        Assert.assertEquals(testData.getValue(3), 1);
+        Assert.assertEquals(testData.getValue(4), 3);
+        Assert.assertEquals(histogramData.getInteger(
+                HistogramRequestHandler.LEFT_OUTLIER_COUNT_KEY).intValue(), 0);
+        Assert.assertEquals(histogramData.getInteger(
+                HistogramRequestHandler.RIGHT_OUTLIER_COUNT_KEY).intValue(), 0);
+    }
+
+    @Test
+    public void testINT32() {
+        ByteBuffer bb = ByteBuffer.allocate(40);
+        bb.putInt((int) 314025421);
+        bb.putInt((int) -2068008231);
+        bb.putInt((int) 122426751);
+        bb.putInt((int) 308854092);
+        bb.putInt((int) 1524117449);
+        bb.putInt((int) -936228904);
+        bb.putInt((int) -1400983178);
+        bb.putInt((int) 131007035);
+        bb.putInt((int) -1762565678);
+        bb.putInt((int) -841111877);
+        PixelData pd = new PixelData(PixelsType.VALUE_INT32, bb);
+        double[] minMax = new double[] {-2147483648, 2147483647};
+        histogramCtx.bins = 5;
+        JsonObject histogramData = requestHandler.getHistogramData(pd, minMax);
+        JsonArray testData = histogramData.getJsonArray(
+            HistogramRequestHandler.HISTOGRAM_DATA_KEY);
+        Assert.assertEquals(testData.size(), 5);
+        Assert.assertEquals(testData.getValue(0), 3);
+        Assert.assertEquals(testData.getValue(1), 2);
+        Assert.assertEquals(testData.getValue(2), 4);
+        Assert.assertEquals(testData.getValue(3), 0);
+        Assert.assertEquals(testData.getValue(4), 1);
+        Assert.assertEquals(histogramData.getInteger(
+                HistogramRequestHandler.LEFT_OUTLIER_COUNT_KEY).intValue(), 0);
+        Assert.assertEquals(histogramData.getInteger(
+                HistogramRequestHandler.RIGHT_OUTLIER_COUNT_KEY).intValue(), 0);
+    }
+
+    @Test
+    public void testFLOAT() {
+        ByteBuffer bb = ByteBuffer.allocate(40);
+        bb.putFloat((float) 0.3194745);
+        bb.putFloat((float) 0.4041198);
+        bb.putFloat((float) 0.5212703);
+        bb.putFloat((float) 0.8714385);
+        bb.putFloat((float) 0.58057505);
+        bb.putFloat((float) 0.7913712);
+        bb.putFloat((float) 0.6242399);
+        bb.putFloat((float) 0.0665013);
+        bb.putFloat((float) 0.25559694);
+        bb.putFloat((float) 0.7946202);
+        PixelData pd = new PixelData(PixelsType.VALUE_FLOAT, bb);
+        double[] minMax = new double[] {-1, 1};
+        histogramCtx.bins = 5;
+        JsonObject histogramData = requestHandler.getHistogramData(pd, minMax);
+        JsonArray testData = histogramData.getJsonArray(
+            HistogramRequestHandler.HISTOGRAM_DATA_KEY);
+        Assert.assertEquals(testData.size(), 5);
+        Assert.assertEquals(testData.getValue(0), 0);
+        Assert.assertEquals(testData.getValue(1), 0);
+        Assert.assertEquals(testData.getValue(2), 1);
+        Assert.assertEquals(testData.getValue(3), 5);
+        Assert.assertEquals(testData.getValue(4), 4);
+        Assert.assertEquals(histogramData.getInteger(
+                HistogramRequestHandler.LEFT_OUTLIER_COUNT_KEY).intValue(), 0);
+        Assert.assertEquals(histogramData.getInteger(
+                HistogramRequestHandler.RIGHT_OUTLIER_COUNT_KEY).intValue(), 0);
+    }
+
+    @Test
+    public void testDOUBLE() {
+        ByteBuffer bb = ByteBuffer.allocate(80);
+        bb.putDouble(0.3194745);
+        bb.putDouble(0.4041198);
+        bb.putDouble(0.5212703);
+        bb.putDouble(0.8714385);
+        bb.putDouble(0.58057505);
+        bb.putDouble(0.7913712);
+        bb.putDouble(0.6242399);
+        bb.putDouble(0.0665013);
+        bb.putDouble(0.25559694);
+        bb.putDouble(0.7946202);
+        PixelData pd = new PixelData(PixelsType.VALUE_DOUBLE, bb);
+        double[] minMax = new double[] {-1, 1};
+        histogramCtx.bins = 5;
+        JsonObject histogramData = requestHandler.getHistogramData(pd, minMax);
+        JsonArray testData = histogramData.getJsonArray(
+            HistogramRequestHandler.HISTOGRAM_DATA_KEY);
+        Assert.assertEquals(testData.size(), 5);
+        Assert.assertEquals(testData.getValue(0), 0);
+        Assert.assertEquals(testData.getValue(1), 0);
+        Assert.assertEquals(testData.getValue(2), 1);
+        Assert.assertEquals(testData.getValue(3), 5);
+        Assert.assertEquals(testData.getValue(4), 4);
+        Assert.assertEquals(histogramData.getInteger(
+                HistogramRequestHandler.LEFT_OUTLIER_COUNT_KEY).intValue(), 0);
+        Assert.assertEquals(histogramData.getInteger(
+                HistogramRequestHandler.RIGHT_OUTLIER_COUNT_KEY).intValue(), 0);
+    }
 }

--- a/src/test/java/com/glencoesoftware/omero/ms/image/region/HistogramRequestHandlerTest.java
+++ b/src/test/java/com/glencoesoftware/omero/ms/image/region/HistogramRequestHandlerTest.java
@@ -182,11 +182,11 @@ public class HistogramRequestHandlerTest {
         JsonArray testData = histogramData.getJsonArray(
             HistogramRequestHandler.HISTOGRAM_DATA_KEY);
         Assert.assertEquals(testData.size(), 5);
-        Assert.assertEquals(testData.getValue(0), 2);
-        Assert.assertEquals(testData.getValue(1), 1);
-        Assert.assertEquals(testData.getValue(2), 3);
-        Assert.assertEquals(testData.getValue(3), 3);
-        Assert.assertEquals(testData.getValue(4), 1);
+        Assert.assertEquals(testData.getValue(0), 2); // 39, 3
+        Assert.assertEquals(testData.getValue(1), 1); // 63
+        Assert.assertEquals(testData.getValue(2), 3); // 143, 145, 138
+        Assert.assertEquals(testData.getValue(3), 3); // 175, 153, 173
+        Assert.assertEquals(testData.getValue(4), 1); // 218
         Assert.assertEquals(histogramData.getInteger(
                 HistogramRequestHandler.LEFT_OUTLIER_COUNT_KEY).intValue(), 0);
         Assert.assertEquals(histogramData.getInteger(
@@ -213,11 +213,11 @@ public class HistogramRequestHandlerTest {
         JsonArray testData = histogramData.getJsonArray(
             HistogramRequestHandler.HISTOGRAM_DATA_KEY);
         Assert.assertEquals(testData.size(), 5);
-        Assert.assertEquals(testData.getValue(0), 3);
-        Assert.assertEquals(testData.getValue(1), 2);
-        Assert.assertEquals(testData.getValue(2), 1);
-        Assert.assertEquals(testData.getValue(3), 2);
-        Assert.assertEquals(testData.getValue(4), 2);
+        Assert.assertEquals(testData.getValue(0), 3); //-92, -95, -78
+        Assert.assertEquals(testData.getValue(1), 2); //-50, -68
+        Assert.assertEquals(testData.getValue(2), 1); //-18
+        Assert.assertEquals(testData.getValue(3), 2); //40, 48
+        Assert.assertEquals(testData.getValue(4), 2); //101, 82
         Assert.assertEquals(histogramData.getInteger(
                 HistogramRequestHandler.LEFT_OUTLIER_COUNT_KEY).intValue(), 0);
         Assert.assertEquals(histogramData.getInteger(
@@ -244,10 +244,10 @@ public class HistogramRequestHandlerTest {
         JsonArray testData = histogramData.getJsonArray(
             HistogramRequestHandler.HISTOGRAM_DATA_KEY);
         Assert.assertEquals(testData.size(), 5);
-        Assert.assertEquals(testData.getValue(0), 4);
-        Assert.assertEquals(testData.getValue(1), 2);
-        Assert.assertEquals(testData.getValue(2), 3);
-        Assert.assertEquals(testData.getValue(3), 1);
+        Assert.assertEquals(testData.getValue(0), 4); // 2760, 1425, 11986, 11077
+        Assert.assertEquals(testData.getValue(1), 2); // 21533, 14880
+        Assert.assertEquals(testData.getValue(2), 3); // 38752, 36269, 34827
+        Assert.assertEquals(testData.getValue(3), 1); // 46156
         Assert.assertEquals(testData.getValue(4), 0);
         Assert.assertEquals(histogramData.getInteger(
                 HistogramRequestHandler.LEFT_OUTLIER_COUNT_KEY).intValue(), 0);
@@ -275,11 +275,11 @@ public class HistogramRequestHandlerTest {
         JsonArray testData = histogramData.getJsonArray(
             HistogramRequestHandler.HISTOGRAM_DATA_KEY);
         Assert.assertEquals(testData.size(), 5);
-        Assert.assertEquals(testData.getValue(0), 2);
-        Assert.assertEquals(testData.getValue(1), 4);
-        Assert.assertEquals(testData.getValue(2), 1);
-        Assert.assertEquals(testData.getValue(3), 1);
-        Assert.assertEquals(testData.getValue(4), 2);
+        Assert.assertEquals(testData.getValue(0), 2); // -31711, -21571
+        Assert.assertEquals(testData.getValue(1), 4); // -19497, -11285, -17219, -12075
+        Assert.assertEquals(testData.getValue(2), 1); // 1187
+        Assert.assertEquals(testData.getValue(3), 1); // 6841
+        Assert.assertEquals(testData.getValue(4), 2); // 26833, 28521
         Assert.assertEquals(histogramData.getInteger(
                 HistogramRequestHandler.LEFT_OUTLIER_COUNT_KEY).intValue(), 0);
         Assert.assertEquals(histogramData.getInteger(
@@ -306,11 +306,11 @@ public class HistogramRequestHandlerTest {
         JsonArray testData = histogramData.getJsonArray(
             HistogramRequestHandler.HISTOGRAM_DATA_KEY);
         Assert.assertEquals(testData.size(), 5);
-        Assert.assertEquals(testData.getValue(0), 2);
-        Assert.assertEquals(testData.getValue(1), 2);
-        Assert.assertEquals(testData.getValue(2), 2);
-        Assert.assertEquals(testData.getValue(3), 1);
-        Assert.assertEquals(testData.getValue(4), 3);
+        Assert.assertEquals(testData.getValue(0), 2); // 642532262L, 433606742L
+        Assert.assertEquals(testData.getValue(1), 2); // 1039053181L, 1356288417L
+        Assert.assertEquals(testData.getValue(2), 2); // 1966804319L, 2289077882L
+        Assert.assertEquals(testData.getValue(3), 1); // 3411013609L
+        Assert.assertEquals(testData.getValue(4), 3); // 3513814796L, 4100655705L, 3585211196L
         Assert.assertEquals(histogramData.getInteger(
                 HistogramRequestHandler.LEFT_OUTLIER_COUNT_KEY).intValue(), 0);
         Assert.assertEquals(histogramData.getInteger(
@@ -337,11 +337,11 @@ public class HistogramRequestHandlerTest {
         JsonArray testData = histogramData.getJsonArray(
             HistogramRequestHandler.HISTOGRAM_DATA_KEY);
         Assert.assertEquals(testData.size(), 5);
-        Assert.assertEquals(testData.getValue(0), 3);
-        Assert.assertEquals(testData.getValue(1), 2);
-        Assert.assertEquals(testData.getValue(2), 4);
+        Assert.assertEquals(testData.getValue(0), 3); // -2068008231, -1400983178, -1762565678
+        Assert.assertEquals(testData.getValue(1), 2); // -936228904, -841111877
+        Assert.assertEquals(testData.getValue(2), 4); // 314025421, 122426751, 308854092, 131007035
         Assert.assertEquals(testData.getValue(3), 0);
-        Assert.assertEquals(testData.getValue(4), 1);
+        Assert.assertEquals(testData.getValue(4), 1); //1524117449
         Assert.assertEquals(histogramData.getInteger(
                 HistogramRequestHandler.LEFT_OUTLIER_COUNT_KEY).intValue(), 0);
         Assert.assertEquals(histogramData.getInteger(
@@ -370,9 +370,9 @@ public class HistogramRequestHandlerTest {
         Assert.assertEquals(testData.size(), 5);
         Assert.assertEquals(testData.getValue(0), 0);
         Assert.assertEquals(testData.getValue(1), 0);
-        Assert.assertEquals(testData.getValue(2), 1);
-        Assert.assertEquals(testData.getValue(3), 5);
-        Assert.assertEquals(testData.getValue(4), 4);
+        Assert.assertEquals(testData.getValue(2), 1); // 0.0665013
+        Assert.assertEquals(testData.getValue(3), 5); // 0.3194745, 0.4041198, 0.5212703, 0.58057505, 0.25559694
+        Assert.assertEquals(testData.getValue(4), 4); // 0.8714385, 0.7913712, 0.6242399, 0.7946202
         Assert.assertEquals(histogramData.getInteger(
                 HistogramRequestHandler.LEFT_OUTLIER_COUNT_KEY).intValue(), 0);
         Assert.assertEquals(histogramData.getInteger(
@@ -401,9 +401,9 @@ public class HistogramRequestHandlerTest {
         Assert.assertEquals(testData.size(), 5);
         Assert.assertEquals(testData.getValue(0), 0);
         Assert.assertEquals(testData.getValue(1), 0);
-        Assert.assertEquals(testData.getValue(2), 1);
-        Assert.assertEquals(testData.getValue(3), 5);
-        Assert.assertEquals(testData.getValue(4), 4);
+        Assert.assertEquals(testData.getValue(2), 1); // 0.0665013
+        Assert.assertEquals(testData.getValue(3), 5); // 0.3194745, 0.4041198, 0.5212703, 0.58057505, 0.25559694
+        Assert.assertEquals(testData.getValue(4), 4); // 0.8714385, 0.7913712, 0.6242399, 0.7946202
         Assert.assertEquals(histogramData.getInteger(
                 HistogramRequestHandler.LEFT_OUTLIER_COUNT_KEY).intValue(), 0);
         Assert.assertEquals(histogramData.getInteger(


### PR DESCRIPTION
See https://github.com/glencoesoftware/omero-ms-image-region/pull/125#discussion_r1157028538. During the review of the histogram endpoint, it was suspected that the bin assignment might be incorrect for non-integer pixel types. The endpoint was nevertheless integrated with an implementation identical to the one used in the omero-server component with the expectation to review this implementation separately.

This PR update the set of histogram unit tests to:
- ensure that both the bin data and the outliers are asserted for each scenarios 
- add additional test cases covering all supported pixel types (int8, uint8, int16, uint16, int32, uint32, float, double).

For each pixel type test, the ground truth  was computed using [numpy.histogram](https://numpy.org/doc/stable/reference/generated/numpy.histogram.html)

```
>>> numpy.histogram([1,2,3,4], bins=4, range=[0,4])
(array([0, 1, 1, 2]), array([0., 1., 2., 3., 4.]))
>>> numpy.histogram([0,1,3], bins=5, range=[0,3])
(array([1, 1, 0, 0, 1]), array([0. , 0.6, 1.2, 1.8, 2.4, 3. ]))
>>> numpy.histogram([175,153,63,173,143,218,145,39,138,3], bins=5, range=[0,255])
(array([2, 1, 3, 3, 1]), array([  0.,  51., 102., 153., 204., 255.]))
>>> numpy.histogram([101, -50,  82,  40, -68, -18, -92, -95,  48, -78], bins=5, range=[-128,127])
(array([3, 2, 1, 2, 2]), array([-128.,  -77.,  -26.,   25.,   76.,  127.]))
>>> numpy.histogram([21533, 38752,   36269, 2760,  1425,  14880, 34827, 11986, 11077,   46156], bins=5, range=[0, 65535])
(array([4, 2, 3, 1, 0]), array([    0., 13107., 26214., 39321., 52428., 65535.]))
>>> numpy.histogram([-19497, -11285,   1187, -17219,  26833,  28521, -31711, -21571, -12075,   6841], bins=5, range=[-32768, 32767])
(array([2, 4, 1, 1, 2]), array([-32768., -19661.,  -6554.,   6553.,  19660.,  32767.]))
>>> numpy.histogram([1039053181, 1966804319, 3513814796,  642532262, 3411013609,
...         433606742, 2289077882, 4100655705, 3585211196, 1356288417], bins=5, range=[0,4294967295])
(array([2, 2, 2, 1, 3]), array([0.00000000e+00, 8.58993459e+08, 1.71798692e+09, 2.57698038e+09,
       3.43597384e+09, 4.29496730e+09]))
>>> numpy.histogram([  314025421, -2068008231,   122426751,   308854092,  1524117449,
...         -936228904, -1400983178,   131007035, -1762565678,  -841111877], bins=5, range=[-2147483648,2147483647])
(array([3, 2, 4, 0, 1]), array([-2.14748365e+09, -1.28849019e+09, -4.29496730e+08,  4.29496729e+08,
        1.28849019e+09,  2.14748365e+09]))
>>> numpy.histogram([0.3194745 , 0.4041198 , 0.52127033, 0.8714385 , 0.58057505,
...        0.7913712 , 0.6242399 , 0.0665013 , 0.25559694, 0.7946202 ],bins=5, range=[-1,1])
(array([0, 0, 1, 5, 4]), array([-1. , -0.6, -0.2,  0.2,  0.6,  1. ]))
```

[48cb811](https://github.com/glencoesoftware/omero-ms-image-region/pull/128/commits/48cb8112e1fd4729f52e87e38577eb81a815acfb) fixes the bin assignment logic for all pixel types using a logic similar to the one using by numpy.histogram - see https://github.com/numpy/numpy/blob/8cec82012694571156e8d7696307c848a7603b4e/numpy/lib/histograms.py#L836-L840. The outlier detection logic is also moved prior to the bin assignment to prevent the bin index from being unnecessarily computed.