### PR TITLE
Bump aws-java-sdk-s3 library to the latest release on the 1.11.x branch

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -83,6 +83,7 @@ dependencies {
     implementation 'com.google.code.gson:gson:2.8.6'
     implementation 'com.bc.zarr:jzarr:0.3.4'
     implementation 'org.lasersonlab:s3fs:2.2.3'
+    implementation 'com.amazonaws:aws-java-sdk-s3:1.11.1034'
 
     testImplementation("junit:junit:4.12")
     testImplementation 'org.mockito:mockito-core:2.28.2'


### PR DESCRIPTION
https://github.com/glencoesoftware/omero-ms-image-region/pull/117 added support for the [EC2 instance profile](https://docs.aws.amazon.com/IAM/latest/UserGuide/id_roles_use_switch-role-ec2_instance-profiles.html) in order to accessing NGFF data hosted on AWS S3.

While this approach has been successful under several conditions, we recently came across examples of EC2 instances configured with an instance profile to assume an IAM role giving access to  some S3 buckets where the pixel service could not access the data. The image-region micro-service logs will give a stack trace similar to:

```
2023-08-18 07:36:06,612 [render-image-region-pool-1] INFO  c.g.o.ms.image.region.PixelsService - OME-NGFF root is: s3://s3.us-east-1.amazonaws.com/gs-public-zarr-archive/CMU-1.ome.zarr/0
2023-08-18 07:36:06,616 [render-image-region-pool-2] WARN  c.g.o.ms.image.region.PixelsService - Getting OME-NGFF pixel buffer failed - attempting to get local data
com.amazonaws.SdkClientException: Unable to load AWS credentials from any provider in the chain
	at com.amazonaws.auth.AWSCredentialsProviderChain.getCredentials(AWSCredentialsProviderChain.java:131)
	at com.amazonaws.http.AmazonHttpClient$RequestExecutor.getCredentialsFromContext(AmazonHttpClient.java:1164)
	at com.amazonaws.http.AmazonHttpClient$RequestExecutor.runBeforeRequestHandlers(AmazonHttpClient.java:762)
	at com.amazonaws.http.AmazonHttpClient$RequestExecutor.doExecute(AmazonHttpClient.java:724)
	at com.amazonaws.http.AmazonHttpClient$RequestExecutor.executeWithTimer(AmazonHttpClient.java:717)
	at com.amazonaws.http.AmazonHttpClient$RequestExecutor.execute(AmazonHttpClient.java:699)
	at com.amazonaws.http.AmazonHttpClient$RequestExecutor.access$500(AmazonHttpClient.java:667)
	at com.amazonaws.http.AmazonHttpClient$RequestExecutionBuilderImpl.execute(AmazonHttpClient.java:649)
	at com.amazonaws.http.AmazonHttpClient.execute(AmazonHttpClient.java:513)
	at com.amazonaws.services.s3.AmazonS3Client.invoke(AmazonS3Client.java:4319)
	at com.amazonaws.services.s3.AmazonS3Client.invoke(AmazonS3Client.java:4266)
	at com.amazonaws.services.s3.AmazonS3Client.getObjectMetadata(AmazonS3Client.java:1261)
	at com.amazonaws.services.s3.AmazonS3Client.getObjectMetadata(AmazonS3Client.java:1236)
	at com.upplication.s3fs.util.S3Utils.getS3ObjectSummary(S3Utils.java:37)
	at com.upplication.s3fs.util.S3Utils.getS3FileAttributes(S3Utils.java:86)
	at com.upplication.s3fs.S3FileSystemProvider.readAttributes(S3FileSystemProvider.java:497)
	at java.base/java.nio.file.Files.readAttributes(Files.java:1764)
	at java.base/java.nio.file.Files.isDirectory(Files.java:2235)
	at com.bc.zarr.ZarrUtils.ensureDirectory(ZarrUtils.java:155)
	at com.bc.zarr.ZarrGroup.open(ZarrGroup.java:94)
	at com.glencoesoftware.omero.ms.image.region.ZarrPixelBuffer.<init>(ZarrPixelBuffer.java:92)
...
```

After investigation, we established a relationship with the [two versions of the Instance Metadata Service](https://docs.aws.amazon.com/AWSEC2/latest/UserGuide/configuring-instance-metadata-service.html) and the lack of support for IMDSv2. On a test EC2 instance previously set-up with an instance profile and successfully tested against some NGFF data, disabling IMDSv1 and forcing IMDSv2 via an AWS configuration change is sufficient to reproduce the stack trace above on NGFF data.

The problem is related to the `com.amazonaws:aws-sdk-java-*` libraries currently shipped in the micro-service transitively through `org.lasersonlab:s3fs:2.2.3`. The current version (`1.11.232`) is almost 6 years old and predates the support for IMDSv2.
 
The PR proposes the minimal set of changes to ugprade the `com.amazonaws:aws-java-sdk-s3` library to its latest release on the 1.11.x line, namely 1.11.1034. This version is still 2 years old and in time we might need to consider upgrading the 1.12.x line but this felt like the most straightforward change allowing to support EC2 instances configured with IMDSv2. The following dependencies should be bumped as part of this change:
- `com.amazonaws:aws-java-sdk-s3:1.11.232 -> 1.11.1034`
- `com.amazonaws:aws-java-sdk-core:1.11.232 -> 1.11.1034`
- `com.amazonaws:aws-java-sdk-kms:1.11.232 -> 1.11.1034`
- `com.amazonaws:jmespath-java:1.11.232 -> 1.11.1034`
- `commons-codec:commons-codec:1.12->1.15`
- `org.apache.httpcomponents:httpclient:4.5.9->4.5.13`
- `org.apache.httpcomponents:httpcore:4.4.11->4.4.13`

In terms of testing, the reading of existing NGFF data (images or labels) should be unaffected and still functional for the following conditions:
- NGFF hosted on the filesystem
- NGFF hosted on AWS S3 and accessed via a named profile
- NGFF hosted on AWS S3 and accessed via an EC2 instance profile using IMDSv1
 In addition NGFF data  hosted on AWS S3 and accessed via on EC2 instance profile using IMDSv2 should now be working
