### PR TITLE
First pass at fixing imgData endpoint for  multi-dataset images

### DIFF
--- a/src/main/java/com/glencoesoftware/omero/ms/image/region/ImageDataRequestHandler.java
+++ b/src/main/java/com/glencoesoftware/omero/ms/image/region/ImageDataRequestHandler.java
@@ -252,7 +252,7 @@ public class ImageDataRequestHandler {
         meta.putNull("projectId");
         meta.put("projectDescription", "");
         List<Dataset> datasets = image.linkedDatasetList();
-        if (datasets != null && datasets.size() > 1) {
+        if (datasets.size() > 1) {
             Set<Long> projectIds = new HashSet<Long>();
             for (Dataset ds : datasets) {
                 List<Project> projects = ds.linkedProjectList();

--- a/src/main/java/com/glencoesoftware/omero/ms/image/region/ImageDataRequestHandler.java
+++ b/src/main/java/com/glencoesoftware/omero/ms/image/region/ImageDataRequestHandler.java
@@ -249,23 +249,27 @@ public class ImageDataRequestHandler {
                 List<Project> projects = ds.linkedProjectList();
                 if (projects.size() > 1) {
                     meta.put("projectName", "Multiple");
+                    meta.remove("projectId");
+                    meta.remove("projectDescription");
                     break;
                 } else if (projects.size() == 1) {
                     if (!projectIds.isEmpty() && !projectIds
                             .contains(projects.get(0).getId().getValue())) {
                         meta.put("projectName", "Multiple");
+                        meta.remove("projectId");
+                        meta.remove("projectDescription");
                         break;
                     } else {
-                        projectIds.add(projects.get(0).getId().getValue());
+                        Project project = projects.get(0);
+                        projectIds.add(project.getId().getValue());
+                        // In case this is the only dataset with a project,
+                        // set the properties here
+                        meta.put("projectName", unwrap(project.getName()));
+                        meta.put("projectId", project.getId().getValue());
+                        meta.put("projectDescription",
+                                unwrap(project.getDescription()));
                     }
                 }
-            }
-            if (!meta.containsKey("projectName")) {
-                Project project = datasets.get(0).linkedProjectList().get(0);
-                meta.put("projectName", unwrap(project.getName()));
-                meta.put("projectId", project.getId().getValue());
-                meta.put("projectDescription",
-                        unwrap(project.getDescription()));
             }
         } else if (datasets.size() == 1) {
             Dataset ds = datasets.get(0);

--- a/src/test/java/com/glencoesoftware/omero/ms/image/region/ImageDataRequestHandlerTest.java
+++ b/src/test/java/com/glencoesoftware/omero/ms/image/region/ImageDataRequestHandlerTest.java
@@ -534,7 +534,7 @@ public class ImageDataRequestHandlerTest extends AbstractZarrPixelBufferTest {
                 image, pixelBuffer, rdefs, OWNER_ID);
         Assert.assertEquals(basicObj, imgData);
     }
-    
+
     @Test
     public void testImageDataSingleDataset() throws ApiUsageException {
         ImageDataCtx ctx = new ImageDataCtx();
@@ -552,9 +552,9 @@ public class ImageDataRequestHandlerTest extends AbstractZarrPixelBufferTest {
         singleDsCorrect.getJsonObject("meta").put("datasetName", DATASET_NAME_1);
         singleDsCorrect.getJsonObject("meta").put("datasetId", DATASET_ID_1);
         singleDsCorrect.getJsonObject("meta").put("datasetDescription", DATASET_DESC_1);
-        singleDsCorrect.getJsonObject("meta").remove("projectName");
-        singleDsCorrect.getJsonObject("meta").remove("projectId");
-        singleDsCorrect.getJsonObject("meta").remove("projectDescription");
+        singleDsCorrect.getJsonObject("meta").put("projectName", "Multiple");
+        singleDsCorrect.getJsonObject("meta").putNull("projectId");
+        singleDsCorrect.getJsonObject("meta").put("projectDescription", "");
         Assert.assertEquals(basicObj, singleDsCorrect);
     }
 
@@ -612,8 +612,8 @@ public class ImageDataRequestHandlerTest extends AbstractZarrPixelBufferTest {
         multProjCorrect.getJsonObject("meta").put("datasetDescription", DATASET_DESC_1);
         multProjCorrect.getJsonObject("meta").put("projectName",
                 "Multiple");
-        multProjCorrect.getJsonObject("meta").remove("projectId");
-        multProjCorrect.getJsonObject("meta").remove("projectDescription");
+        multProjCorrect.getJsonObject("meta").putNull("projectId");
+        multProjCorrect.getJsonObject("meta").put("projectDescription", "");
         Assert.assertEquals(basicObj, multProjCorrect);
     }
 
@@ -637,11 +637,11 @@ public class ImageDataRequestHandlerTest extends AbstractZarrPixelBufferTest {
                 image, pixelBuffer, rdefs, OWNER_ID);
         JsonObject multDsCorrect = imgData.copy();
         multDsCorrect.getJsonObject("meta").put("datasetName", "Multiple");
-        multDsCorrect.getJsonObject("meta").remove("datasetId");
-        multDsCorrect.getJsonObject("meta").remove("datasetDescription");
-        multDsCorrect.getJsonObject("meta").remove("projectName");
-        multDsCorrect.getJsonObject("meta").remove("projectId");
-        multDsCorrect.getJsonObject("meta").remove("projectDescription");
+        multDsCorrect.getJsonObject("meta").putNull("datasetId");
+        multDsCorrect.getJsonObject("meta").put("datasetDescription", "");
+        multDsCorrect.getJsonObject("meta").put("projectName", "Multiple");
+        multDsCorrect.getJsonObject("meta").putNull("projectId");
+        multDsCorrect.getJsonObject("meta").put("projectDescription", "");
         Assert.assertEquals(basicObj, multDsCorrect);
     }
 
@@ -669,8 +669,8 @@ public class ImageDataRequestHandlerTest extends AbstractZarrPixelBufferTest {
                 image, pixelBuffer, rdefs, OWNER_ID);
         JsonObject multDs1ProjCorrect = imgData.copy();
         multDs1ProjCorrect.getJsonObject("meta").put("datasetName", "Multiple");
-        multDs1ProjCorrect.getJsonObject("meta").remove("datasetId");
-        multDs1ProjCorrect.getJsonObject("meta").remove("datasetDescription");
+        multDs1ProjCorrect.getJsonObject("meta").putNull("datasetId");
+        multDs1ProjCorrect.getJsonObject("meta").put("datasetDescription", "");
         multDs1ProjCorrect.getJsonObject("meta").put("projectName", PROJECT_NAME_1);
         multDs1ProjCorrect.getJsonObject("meta").put("projectId", PROJECT_ID_1);
         multDs1ProjCorrect.getJsonObject("meta").put("projectDescription", PROJECT_DESC_1);
@@ -706,15 +706,14 @@ public class ImageDataRequestHandlerTest extends AbstractZarrPixelBufferTest {
         JsonObject multDsProjCorrect = imgData.copy();
         multDsProjCorrect.getJsonObject("meta").put("datasetName",
                 "Multiple");
-        multDsProjCorrect.getJsonObject("meta").remove("datasetId");
-        multDsProjCorrect.getJsonObject("meta")
-                .remove("datasetDescription");
+        multDsProjCorrect.getJsonObject("meta").putNull("datasetId");
+        multDsProjCorrect.getJsonObject("meta").put("datasetDescription", "");
 
         multDsProjCorrect.getJsonObject("meta").put("projectName",
                 "Multiple");
-        multDsProjCorrect.getJsonObject("meta").remove("projectId");
+        multDsProjCorrect.getJsonObject("meta").putNull("projectId");
         multDsProjCorrect.getJsonObject("meta")
-                .remove("projectDescription");
+                .put("projectDescription", "");
         Assert.assertEquals(basicObj, multDsProjCorrect);
     }
 


### PR DESCRIPTION
Currently, there is a bug in the microservice when retrieving image data for an image which is in multiple datasets, where at most 1 dataset is in a project. 
### To recreate the bug:
 - Create one project testProject and three datasets, testA, testB, and testC. Only put testC into testProject.
 - Import an image into testA and copy a link into testB.
 - Hit the endpoint "<host>/pathviewer/imgData/<imageId>/" for the image. You will always get back "Cannot find the Image" as a response.
 - Move the image from testB to testC
 - Hit the endpoint "<host>/pathviewer/imgData/<imageId>/" multiple times. Sometimes you will get back the data, sometimes you will get "Cannot find the Image"

With this fix you should always get the data in both cases.