### PR TITLE
Set Status Code Before Writing

### DIFF
--- a/src/main/java/com/glencoesoftware/omero/ms/image/region/ImageRegionMicroserviceVerticle.java
+++ b/src/main/java/com/glencoesoftware/omero/ms/image/region/ImageRegionMicroserviceVerticle.java
@@ -451,18 +451,29 @@ public class ImageRegionMicroserviceVerticle extends AbstractVerticle {
         Boolean resultFailed = result.failed();
         if (resultFailed) {
             Throwable t = result.cause();
-            int statusCode = 404;
+            // t should always be a ReplyException, but we check anyway
             if (t instanceof ReplyException) {
-                statusCode = ((ReplyException) t).failureCode();
+                int statusCode = ((ReplyException) t).failureCode();
+                // When vertx supplies a ReplyException instead of our code
+                // (e.g. timeout), the failure code may not be an http status code
+                // (it's often -1). We reset these codes to 500.
                 if (statusCode < 200 || statusCode > 599) {
                     log.error(
                         "Unexpected failureCode {} resetting to 500",
                         statusCode, t);
                     statusCode = 500;
                 }
+                // We must set the status code before calling write or the status code
+                // will be fixed to 200 (the default)
                 response.setStatusCode(statusCode);
-                response.end(t.getMessage());
-                response.close();
+                response.headers().set(
+                        "Content-Length",
+                        String.valueOf(t.getMessage().length()));
+                response.write(t.getMessage());
+            } else {
+                // If it's not a ReplyException, return 500
+                log.error("Non-ReplyException received - this shouldn't happen");
+                response.setStatusCode(500);
             }
         }
         return resultFailed;

--- a/src/main/java/com/glencoesoftware/omero/ms/image/region/ImageRegionMicroserviceVerticle.java
+++ b/src/main/java/com/glencoesoftware/omero/ms/image/region/ImageRegionMicroserviceVerticle.java
@@ -463,15 +463,6 @@ public class ImageRegionMicroserviceVerticle extends AbstractVerticle {
                 response.setStatusCode(statusCode);
                 response.end(t.getMessage());
                 response.close();
-            } else {
-                if (statusCode < 200 || statusCode > 599) {
-                    log.error(
-                        "Unexpected failureCode {} resetting to 500",
-                        statusCode, t);
-                    response.setStatusCode(500);
-                    response.end();
-                    response.close();
-                }
             }
         }
         return resultFailed;


### PR DESCRIPTION
Fixes #129 
When errors were received from Verticles, they were handled by the `handleResultFailed` function. Previously, even though these called `setStatusCode` on the response, the response codes were always 200. We determined that this was caused by calling `response.write` prior to `setStatusCode`. We have refactored the code to call `setStatusCode` earlier and have also added comments to explain some of the non-obvious logic.