### PR TITLE
Histogram request: also return 404 on invalid channel index

### DIFF
--- a/src/main/java/com/glencoesoftware/omero/ms/image/region/HistogramRequestHandler.java
+++ b/src/main/java/com/glencoesoftware/omero/ms/image/region/HistogramRequestHandler.java
@@ -173,6 +173,7 @@ public class HistogramRequestHandler {
                     iQuery, Arrays.asList(histogramCtx.imageId));
             Pixels pixels = imagePixels.get(histogramCtx.imageId);
             if (pixels == null ||
+                   histogramCtx.c >= pixels.getSizeC() ||
                    histogramCtx.z >= pixels.getSizeZ() ||
                    histogramCtx.t >= pixels.getSizeT()) {
                 return null;


### PR DESCRIPTION
Fixes #127 

I think #133 addresses most of the issues by rectifying the status code. I could not reproduce the second point i.e. the empty JSON response for some image modalities. The only remaining issue is the handling of non-existing channels in the request.

Without this PR, the micro-service should return a 200 response with an empty JSON. With this PR included, the response should be a 404 status code.