### PR TITLE
Fix memo file regeneration

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,10 +9,10 @@ endpoint for OMERO.web.
 Requirements
 ============
 
-* OMERO 5.4.x+
-* OMERO.web 5.4.x+
+* OMERO 5.6.x+
+* OMERO.web 5.6.x+
 * Redis backed sessions
-* Java 8+
+* Java 11+
 
 Workflow
 ========
@@ -154,7 +154,7 @@ Development Installation
 
 1. Clone the repository::
 
-        git clone git@github.com:glencoesoftware/omero-ms-image-region.git
+        git clone https://github.com/glencoesoftware/omero-ms-image-region.git
 
 1. Run the Gradle build and utilize the artifacts as required::
 

--- a/src/main/resources/beanRefContext.xml
+++ b/src/main/resources/beanRefContext.xml
@@ -8,7 +8,7 @@
 
   <bean name="filesystem"  abstract="true">
     <constructor-arg index="0" value="${omero.data.dir}"/>
-    <constructor-arg index="1" type="boolean" value="false"/>
+    <constructor-arg index="1" type="boolean" value="true"/>
   </bean>
 
   <bean id="omeroFilePathResolver" class="ome.services.OmeroFilePathResolver">


### PR DESCRIPTION
#137 introduces a regression in the memo file regeneration workflow when passing a cache directory different than the default. 9fee5d0f46dcf7d17d24aac54084f2f2abbb7083 fixes the issue by setting the value of the `isReadOnly` argument to `true` in the bean definition file. This flag is a requirement to use the `PixelsService.setMemoizerDirectoryLocal` API and was previously set internally in https://github.com/glencoesoftware/omero-ms-core/blob/d174a81f563d63f1b1690790554c60ca5b91a05a/src/main/java/com/glencoesoftware/omero/ms/core/PixelsService.java#L40.