### PR TITLE
Use left outer join fetch when retrieving the image.format

### DIFF
--- a/src/main/java/com/glencoesoftware/omero/ms/image/region/ImageDataRequestHandler.java
+++ b/src/main/java/com/glencoesoftware/omero/ms/image/region/ImageDataRequestHandler.java
@@ -629,7 +629,7 @@ public class ImageDataRequestHandler {
                     .findByQuery("select i from Image as i"
                             + " left outer join fetch i.details.externalInfo "
                             + " join fetch i.pixels as p"
-                            + " join fetch i.format"
+                            + " left outer join fetch i.format"
                             + " left outer JOIN FETCH i.datasetLinks as links "
                             + " left outer join fetch links.parent as dataset "
                             + " left outer join fetch dataset.projectLinks as plinks "

--- a/src/main/java/com/glencoesoftware/omero/ms/image/region/ImageRegionRequestHandler.java
+++ b/src/main/java/com/glencoesoftware/omero/ms/image/region/ImageRegionRequestHandler.java
@@ -152,7 +152,7 @@ public class ImageRegionRequestHandler {
                     iQuery.findAllByQuery(
                         "select p from Pixels as p "
                         + "join fetch p.image as i "
-                        + "join fetch i.format "
+                        + "left outer join fetch i.format "
                         + "left outer join fetch i.details.externalInfo "
                         + "left outer join fetch i.wellSamples as ws "
                         + "left outer join fetch ws.well as w "


### PR DESCRIPTION
For image where there is no associated format e.g. images that will be read by the RomioPixelBuffer, this is a requirement for the query to return a Pixels object and avoid a Cannot find Image:<id> 404 error when using a micro-service endpoint

This also requires the changes from https://github.com/glencoesoftware/omero-zarr-pixel-buffer/pull/9 to allow the `ZarrPixelsService` checks to handle images where `image.getFormat()` is null.