### PR TITLE
HistogramRequestHandler: fetch image.format in the pixels query

### DIFF
--- a/src/main/java/com/glencoesoftware/omero/ms/image/region/HistogramRequestHandler.java
+++ b/src/main/java/com/glencoesoftware/omero/ms/image/region/HistogramRequestHandler.java
@@ -267,6 +267,7 @@ public class HistogramRequestHandler {
                     iQuery.findAllByQuery(
                         "select p from Pixels as p "
                         + "join fetch p.image as i "
+                        + "left outer join fetch i.format "
                         + "left outer join fetch i.details.externalInfo "
                         + "join fetch p.pixelsType "
                         + "join fetch p.channels as c "


### PR DESCRIPTION
This allows the object to be loaded with all the metadata required for the ZarrPixelsService checks