### PR TITLE
Use wildcard for the micro-service classpath

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -111,6 +111,10 @@ distributions {
     }
 }
 
+startScripts {
+  classpath  = files('$APP_HOME/lib/*')
+}
+
 task memoRegenStartScript(type: CreateStartScripts) {
     mainClass = "com.glencoesoftware.omero.ms.image.region.MemoRegenerator"
     classpath = startScripts.classpath


### PR DESCRIPTION
This pattern improves the extensibility of the micro-service as extension JARs can easily be added to lib/ folder and will be included at restart without the requirement to modify the CLASSPATH in the omero-ms-image-region executable