### PR TITLE
Re-include xalan as a dependency of the image-region micro-service

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -51,7 +51,6 @@ configurations.all {
     exclude group: 'org.quartz-scheduler'
     exclude group: 'org.subethamail'
     exclude group: 'xerces'
-    exclude group: 'xalan'
 }
 
 dependencies {

--- a/src/test/java/com/glencoesoftware/omero/ms/image/region/MemoRegeneratorTest.java
+++ b/src/test/java/com/glencoesoftware/omero/ms/image/region/MemoRegeneratorTest.java
@@ -1,0 +1,29 @@
+/*
+ * Copyright (C) 2024 Glencoe Software, Inc. All rights reserved.
+ *
+ * This program is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation; either version 2 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License along
+ * with this program; if not, write to the Free Software Foundation, Inc.,
+ * 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
+ */
+
+package com.glencoesoftware.omero.ms.image.region;
+
+import org.junit.Test;
+
+public class MemoRegeneratorTest {
+
+    @Test
+    public void testXalan() throws ClassNotFoundException {
+        Class c = Class.forName("org.apache.xalan.xslt.EnvironmentCheck");
+    }
+}


### PR DESCRIPTION
This library is required for upgrading older version of the OME-XML schema (currently at 2016-06) using the XSLT transformation sheets in the memo regeneration utility.
Without it, the XML transformation will fail and the reader stack will typically fallback to the generic TIFF reader causing metadata mismatch when reading planes/series greater than zero.

This can be tested by importing a multidimensional multi-file OME-TIFF created with an old version of the OME data model e.g. https://downloads.openmicroscopy.org/images/OME-TIFF/2013-06/tubhiswt-4D/ and regenerating the memo file using the utility shipped with the micro-service. With the current version of the micro-service, the memo file will be generated using the standard TIFF reader and any rendering call on a plane other than the first one should result in an `Error instantiating pixel buffer` due to an underlying `java.lang.IllegalArgumentException`.
With this PR included, the rendering calls should work as expected for all planes