### PR TITLE
regen-memo-files: use the --db argument when supplied

### DIFF
--- a/src/dist/regen-memo-files.sh
+++ b/src/dist/regen-memo-files.sh
@@ -161,8 +161,10 @@ else
     DB_HOST=$( grep omero.db.host ${MS_CONFIG} |awk -F: '{ print $2 }' | sed -re 's/\s+//g' -e 's/\"//g')
     DB_NAME=$( grep omero.db.name ${MS_CONFIG} |awk -F: '{ print $2 }' | sed -re 's/\s+//g' -e 's/\"//g')
     DB_PASS=$( grep omero.db.pass ${MS_CONFIG} |awk -F: '{ print $2 }' | sed -re 's/\s+//g' -e 's/\"//g')
+    PSQL_OPTIONS="postgresql://${DB_USER:-omero}:${DB_PASS:-omero}@${DB_HOST:-localhost}:${DB_PORT:-5432}/${DB_NAME:-omero}"
+  else
+    PSQL_OPTIONS=${DB}
   fi
-  PSQL_OPTIONS="postgresql://${DB_USER:-omero}:${DB_PASS:-omero}@${DB_HOST:-localhost}:${DB_PORT:-5432}/${DB_NAME:-omero}"
   psql ${PSQL_OPTIONS} omero -f ${MEMOIZER_HOME}/memo_regenerator.sql > ${FULL_CSV}
 fi
 [ -n "${DRYRUN}" ] && set -x


### PR DESCRIPTION
The `--db` option was introduced to bypass the internal logic parsing the YAML configuration file and specify the [PSQL connection URI](https://www.postgresql.org/docs/current/libpq-connect.html#LIBPQ-CONNSTRING-URIS) directly via command-line.

As noticed during an upgrade with @erindiel, when `--db` is set, its value is ignored internally in the current release of the micro-service and the connection string is always set to `postgresql://omero:omero@localhost:5432/omero`.

Ideally testing this should happen in an environment where the connection string needs to overwritten e.g. to percent encode a character in the URI. Without this PR, `./regen-memo-files.sh --db postgresql://<db_user>:<db_pass>@<db_host>:<db_port>/<db_name>` should fail at the CSV creation step. With this PR included, the connection should be successful.

Alternatively, in an environment where the database is stored using the default values (`localhost`, `omero/omero`), 
`./regen-memo-files.sh --db postgresql://omero:omero@localhost:5432/does_not_exist` should unexpectedly complete without this PR included but fail as expected with this PR included.
