### PR TITLE
Allow to regenerate memo files for images imported after a specific date

### DIFF
--- a/README.md
+++ b/README.md
@@ -214,6 +214,10 @@ it from the configuration file:
 
     ./regen-memo-files.sh --cache-options /OMERO/BioFormatsCache.new --jobs 4 --db postgresql://user:password@host:port/db
 
+`--since` allows to only regenerate memo files for images imported after a specific date:
+
+    ./regen-memo-files.sh --cache-options /OMERO/BioFormatsCache.new --jobs 4 --since 2025-01-01
+
 Checking the status
 -------------------
 

--- a/src/dist/memo_regenerator.sql
+++ b/src/dist/memo_regenerator.sql
@@ -22,4 +22,4 @@ COPY (SELECT * FROM (
             JOIN job on filesetjoblink.child=job.id
             JOIN uploadjob on job.id=uploadjob.job_id
             JOIN event e1 on job.update_id=e1.id
-)  AS query WHERE query.rank = 1 AND query.importTime > :start_date ORDER BY query.setId desc) TO STDOUT CSV;
+)  AS query WHERE query.rank = 1 AND query.importTime > :'start_date' ORDER BY query.setId desc) TO STDOUT CSV;

--- a/src/dist/memo_regenerator.sql
+++ b/src/dist/memo_regenerator.sql
@@ -9,6 +9,7 @@ COPY (SELECT * FROM (
            pixels.sizeC,
            pixels.sizeT,
            format.value,
+           e2.time AS importTime,
            e2.time - e1.time AS setId,
            rank() OVER (PARTITION BY fileset.id ORDER BY image.id) AS rank
         FROM fileset
@@ -21,4 +22,4 @@ COPY (SELECT * FROM (
             JOIN job on filesetjoblink.child=job.id
             JOIN uploadjob on job.id=uploadjob.job_id
             JOIN event e1 on job.update_id=e1.id
-)  AS query WHERE query.rank = 1 ORDER BY query.setId desc) TO STDOUT CSV;
+)  AS query WHERE query.rank = 1 AND query.importTime > :start_date ORDER BY query.setId desc) TO STDOUT CSV;

--- a/src/dist/regen-memo-files.sh
+++ b/src/dist/regen-memo-files.sh
@@ -38,6 +38,7 @@ usage() {
     echo "    --memoizer-home       Location of image-region micro-service (default: current directory)"
     echo "    --no-ask              Do not ask for confirmation"
     echo "    --no-wait             Do not wait to start generating -- DO IT NOW"
+    echo "    --since               Only regenerate images imported since the specified date (default: 1970-01-01)"
     echo
     echo "Examples:"
     echo "  Regenerate memo files using the current cache directory and all available CPUs"
@@ -108,6 +109,11 @@ while true; do
                 "") echo "No parameter specified for --csv"; break;;
                 *)  FULL_CSV=$2; shift 2;;
             esac;;
+        --since)
+            case "$2" in
+                "") echo "No parameter specified for --since"; break;;
+                *)  SINCE=$2; shift 2;;
+            esac;;
         "") break;;
         *) echo "Unknown keywords $*"; usage 1;;
     esac
@@ -159,6 +165,10 @@ if [ -z "${FULL_CSV}" ]; then
   FULL_CSV="image-list-${DATESTR}.csv"
 fi
 
+if [ -z "${SINCE}" ]; then
+  SINCE="1970-01-01"
+fi
+
 if [ -f "${FULL_CSV}" ]; then
   echo "existing images file"
 else
@@ -175,7 +185,7 @@ else
   else
     PSQL_OPTIONS=${DB}
   fi
-  psql ${PSQL_OPTIONS} omero -f ${MEMOIZER_HOME}/memo_regenerator.sql > ${FULL_CSV}
+  psql ${PSQL_OPTIONS} omero -v start_date=$SINCE -f ${MEMOIZER_HOME}/memo_regenerator.sql > ${FULL_CSV}
 fi
 [ -n "${DRYRUN}" ] && set -x
 


### PR DESCRIPTION
Related to https://github.com/glencoesoftware/omero-ms-image-region/issues/148

The changes made in #150 aimed to improve the distribution of the memo file regeneration to make better use of the resources allocated to the process. This used the initialization time as measured at import time and stored in the database as a proxy to assess the processing time for each fileset.

While reasonable, these assumptions might be challenged by the storage realities e.g. deployments applying data management policies that move data through different tiered storages. For these cases, regenerating all the memo files involves reading all the data from archived/slow storage/.... which might have real implications both in terms of time and billing. 

This PR proposes to mitigate this scenario by specifying an import time cut-off and regenerating only memo files for images imported after this cut-off.

The logic use the image creation time retrieved from the database as well as PSQL variable assignment to filter entries based on the import date. The default behavior is unmodified and should return a CSL files for all images.

To test this PR, compare the outcome of the process with different variants of `--since` arguments

```
./regen-memo-files.sh --cache-options /OMERO/BioFormatsCache.full
./regen-memo-files.sh --cache-options /OMERO/BioFormatsCache.since2024 --since 2024-01-01
./regen-memo-files.sh --cache-options /OMERO/BioFormatsCache.since2025 --since 2025-01-01
```

Future extensions might take advantage of the `image.archived` flag which has been proposed to communicate the archival state of a particular image - see https://github.com/ome/openmicroscopy/issues/6390.

/cc @erindiel @atTODO 

