### PR TITLE
Switch Unidata repository URL to use Glencoe Artifactory mirror

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -16,7 +16,7 @@ repositories {
     mavenLocal()
     maven {
         name 'Unidata'
-        url 'https://artifacts.unidata.ucar.edu/repository/unidata-releases'
+        url 'https://artifacts.glencoesoftware.com/artifactory/unidata-releases'
     }
     maven {
         url 'https://artifacts.glencoesoftware.com/artifactory/ome.releases'


### PR DESCRIPTION
Unidata has been responding with a 403 since the beginning of the week which might be caused by some upstream detection and IP blacklisting - similar to https://central.sonatype.org/faq/403-error-central/#question Given the maintenance state of this repository as communicated in https://www.unidata.ucar.edu/blogs/news/entry/nsf-unidata-pause-in-most, this uses our mirror to download the netcdf artifacts.