### PR TITLE
Make EventBus Timeout Configurable

### DIFF
--- a/src/dist/conf/config.yaml
+++ b/src/dist/conf/config.yaml
@@ -8,6 +8,8 @@ port: 8081
 # max-initial-line-length: 4096
 # max-header-size: 8192
 # max-chunk-size: 8192
+# EventBus Timeout in ms - default is 30000
+event_bus_timeout: 60000
 # Max number of channels to allow per request
 max-active-channels: 10
 # OMERO server that the microservice will communicate with (as a client)


### PR DESCRIPTION
The default timeout for a VertX EventBus request is 30 seconds. Previously, there was no way to change this value in the microservice.

With this PR, it is now possible to add/edit the new `event_bus_timeout` configuration property to set the EventBus timeout (in ms).

