### PR TITLE
Limit Threads Used By Renderer

### DIFF
--- a/src/dist/conf/config.yaml
+++ b/src/dist/conf/config.yaml
@@ -35,8 +35,8 @@ omero.server:
     omero.pixeldata.zarr_cache_size: "500"
     omero.client.viewer.initial_zoom_level: "0"
     omero.client.viewer.interpolate_pixels: "true"
-    omero.core_pool_size: 4
-    omero.max_pool_size: 4
+    omero.core_pool_size: "4"
+    omero.max_pool_size: "4"
 # OMERO.web configuration
 omero.web:
     session_cookie_name: "sessionid"

--- a/src/dist/conf/config.yaml
+++ b/src/dist/conf/config.yaml
@@ -35,6 +35,8 @@ omero.server:
     omero.pixeldata.zarr_cache_size: "500"
     omero.client.viewer.initial_zoom_level: "0"
     omero.client.viewer.interpolate_pixels: "true"
+    omero.core_pool_size: 4
+    omero.max_pool_size: 4
 # OMERO.web configuration
 omero.web:
     session_cookie_name: "sessionid"

--- a/src/main/java/com/glencoesoftware/omero/ms/image/region/ImageRegionMicroserviceVerticle.java
+++ b/src/main/java/com/glencoesoftware/omero/ms/image/region/ImageRegionMicroserviceVerticle.java
@@ -27,6 +27,8 @@ import java.time.format.DateTimeFormatter;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Optional;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.TimeUnit;
 
 import org.apache.tika.Tika;
 import org.slf4j.LoggerFactory;
@@ -124,6 +126,8 @@ public class ImageRegionMicroserviceVerticle extends AbstractVerticle {
     private AsyncReporter<Span> spanReporter;
 
     private Tracing tracing;
+
+    private ExecutorService processor;
 
     /**
      * Entry point method which starts the server event loop and initializes
@@ -227,6 +231,9 @@ public class ImageRegionMicroserviceVerticle extends AbstractVerticle {
         else {
             log.info("JMX Metrics NOT Enabled");
         }
+
+        processor = (ExecutorService)
+                context.getBean("rendering-thread-pool");
 
         verticleFactory = (OmeroVerticleFactory)
                 context.getBean("omero-ms-verticlefactory");
@@ -450,6 +457,13 @@ public class ImageRegionMicroserviceVerticle extends AbstractVerticle {
         }
         if (sender != null) {
             sender.close();
+        }
+        //Terminate all rendering tasks and don't start any queued ones.
+        processor.shutdownNow();
+        if (!processor.awaitTermination(5, TimeUnit.SECONDS)) {
+            log.error("Failed to terminate all rendering threads.");
+        } else {
+            log.info("All rendering threads terminated successfully");
         }
     }
 

--- a/src/main/java/com/glencoesoftware/omero/ms/image/region/ImageRegionRequestHandler.java
+++ b/src/main/java/com/glencoesoftware/omero/ms/image/region/ImageRegionRequestHandler.java
@@ -111,10 +111,6 @@ public class ImageRegionRequestHandler {
     /** Configured maximum size size in either dimension */
     private final int maxTileLength;
     
-    /** Rendering ThreadPool sizes */
-    private final int corePoolSize;
-    private final int maxPoolSize;
-
     /** Rendering ThreadPool ExecutorService*/
     ExecutorService processor;
 
@@ -130,8 +126,6 @@ public class ImageRegionRequestHandler {
             LocalCompress compressionSrv,
             int maxTileLength,
             ZarrPixelsService pixelsService,
-            int corePoolSize,
-            int maxPoolSize,
             ExecutorService processor) {
         this.compressionSrv = compressionSrv;
         this.lutProvider = lutProvider;
@@ -140,8 +134,6 @@ public class ImageRegionRequestHandler {
         this.pixelsService = pixelsService;
         this.imageRegionCtx = imageRegionCtx;
         this.maxTileLength = maxTileLength;
-        this.corePoolSize = corePoolSize;
-        this.maxPoolSize = maxPoolSize;
         this.processor = processor;
         projectionService = new ProjectionService();
     }

--- a/src/main/java/com/glencoesoftware/omero/ms/image/region/ImageRegionRequestHandler.java
+++ b/src/main/java/com/glencoesoftware/omero/ms/image/region/ImageRegionRequestHandler.java
@@ -110,10 +110,13 @@ public class ImageRegionRequestHandler {
 
     /** Configured maximum size size in either dimension */
     private final int maxTileLength;
-
+    
     /** Rendering ThreadPool sizes */
     private final int corePoolSize;
     private final int maxPoolSize;
+
+    /** Rendering ThreadPool ExecutorService*/
+    ExecutorService processor;
 
     /**
      * Default constructor.
@@ -128,7 +131,8 @@ public class ImageRegionRequestHandler {
             int maxTileLength,
             ZarrPixelsService pixelsService,
             int corePoolSize,
-            int maxPoolSize) {
+            int maxPoolSize,
+            ExecutorService processor) {
         this.compressionSrv = compressionSrv;
         this.lutProvider = lutProvider;
         this.families = families;
@@ -138,6 +142,7 @@ public class ImageRegionRequestHandler {
         this.maxTileLength = maxTileLength;
         this.corePoolSize = corePoolSize;
         this.maxPoolSize = maxPoolSize;
+        this.processor = processor;
         projectionService = new ProjectionService();
     }
 
@@ -530,8 +535,6 @@ public class ImageRegionRequestHandler {
         span.tag("omero.pixels_id", pixels.getId().toString());
         Renderer renderer = null;
         try (PixelBuffer pixelBuffer = getPixelBuffer(pixels)) {
-            BlockingQueue<Runnable> blockingQueue = new LinkedBlockingQueue<Runnable>();
-            ExecutorService processor = new ThreadPoolExecutor(corePoolSize, maxPoolSize, 0L, TimeUnit.MILLISECONDS, blockingQueue);
             renderer = new Renderer(
                 quantumFactory, renderingModels, pixels, renderingDef,
                 pixelBuffer, lutProvider, processor

--- a/src/main/java/com/glencoesoftware/omero/ms/image/region/ImageRegionRequestHandler.java
+++ b/src/main/java/com/glencoesoftware/omero/ms/image/region/ImageRegionRequestHandler.java
@@ -29,6 +29,14 @@ import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.Optional;
+
+import java.util.concurrent.BlockingQueue;
+import java.util.concurrent.Callable;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+import java.util.concurrent.LinkedBlockingQueue;
+import java.util.concurrent.ThreadPoolExecutor;
+import java.util.concurrent.TimeUnit;
 import java.lang.IllegalArgumentException;
 import java.lang.Math;
 
@@ -103,6 +111,10 @@ public class ImageRegionRequestHandler {
     /** Configured maximum size size in either dimension */
     private final int maxTileLength;
 
+    /** Rendering ThreadPool sizes */
+    private final int corePoolSize;
+    private final int maxPoolSize;
+
     /**
      * Default constructor.
      * @param imageRegionCtx {@link ImageRegionCtx} object
@@ -114,7 +126,9 @@ public class ImageRegionRequestHandler {
             LutProvider lutProvider,
             LocalCompress compressionSrv,
             int maxTileLength,
-            ZarrPixelsService pixelsService) {
+            ZarrPixelsService pixelsService,
+            int corePoolSize,
+            int maxPoolSize) {
         this.compressionSrv = compressionSrv;
         this.lutProvider = lutProvider;
         this.families = families;
@@ -122,6 +136,8 @@ public class ImageRegionRequestHandler {
         this.pixelsService = pixelsService;
         this.imageRegionCtx = imageRegionCtx;
         this.maxTileLength = maxTileLength;
+        this.corePoolSize = corePoolSize;
+        this.maxPoolSize = maxPoolSize;
         projectionService = new ProjectionService();
     }
 
@@ -514,9 +530,11 @@ public class ImageRegionRequestHandler {
         span.tag("omero.pixels_id", pixels.getId().toString());
         Renderer renderer = null;
         try (PixelBuffer pixelBuffer = getPixelBuffer(pixels)) {
+            BlockingQueue<Runnable> blockingQueue = new LinkedBlockingQueue<Runnable>();
+            ExecutorService processor = new ThreadPoolExecutor(corePoolSize, maxPoolSize, 0L, TimeUnit.MILLISECONDS, blockingQueue);
             renderer = new Renderer(
                 quantumFactory, renderingModels, pixels, renderingDef,
-                pixelBuffer, lutProvider
+                pixelBuffer, lutProvider, processor
             );
             int t = Optional.ofNullable(imageRegionCtx.t)
                     .orElse(renderingDef.getDefaultT());

--- a/src/main/java/com/glencoesoftware/omero/ms/image/region/ImageRegionVerticle.java
+++ b/src/main/java/com/glencoesoftware/omero/ms/image/region/ImageRegionVerticle.java
@@ -103,10 +103,6 @@ public class ImageRegionVerticle extends OmeroMsAbstractVerticle {
     /** Scaling service for thumbnails */
     private final IScale iScale;
 
-    /** Rendering ThreadPool sizes */
-    private final int corePoolSize;
-    private final int maxPoolSize;
-
     /** Thread pool for rendering operations */
     private final ExecutorService processor;
 
@@ -123,8 +119,6 @@ public class ImageRegionVerticle extends OmeroMsAbstractVerticle {
             ZarrPixelsService pixelsService,
             IScale iScale,
             OriginalFilesService ioService,
-            int corePoolSize,
-            int maxPoolSize,
             ExecutorService processor)
     {
         this.compressionService = compressionService;
@@ -133,8 +127,6 @@ public class ImageRegionVerticle extends OmeroMsAbstractVerticle {
         this.pixelsService = pixelsService;
         this.iScale = iScale;
         this.ioService = ioService;
-        this.corePoolSize = corePoolSize;
-        this.maxPoolSize = maxPoolSize;
         this.processor = processor;
     }
 
@@ -217,8 +209,6 @@ public class ImageRegionVerticle extends OmeroMsAbstractVerticle {
                             compressionService,
                             maxTileLength,
                             pixelsService,
-                            corePoolSize,
-                            maxPoolSize,
                             processor)::renderImageRegion);
             span.finish();
             if (imageRegion == null) {

--- a/src/main/java/com/glencoesoftware/omero/ms/image/region/ImageRegionVerticle.java
+++ b/src/main/java/com/glencoesoftware/omero/ms/image/region/ImageRegionVerticle.java
@@ -23,6 +23,7 @@ import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.Map.Entry;
+import java.util.concurrent.ExecutorService;
 import java.util.stream.Collectors;
 
 import org.slf4j.LoggerFactory;
@@ -101,9 +102,13 @@ public class ImageRegionVerticle extends OmeroMsAbstractVerticle {
 
     /** Scaling service for thumbnails */
     private final IScale iScale;
-    /** thread pool size for rendering */
+
+    /** Rendering ThreadPool sizes */
     private final int corePoolSize;
     private final int maxPoolSize;
+
+    /** Thread pool for rendering operations */
+    private final ExecutorService processor;
 
     /** Original File Service for getting paths */
     private OriginalFilesService ioService;
@@ -119,7 +124,8 @@ public class ImageRegionVerticle extends OmeroMsAbstractVerticle {
             IScale iScale,
             OriginalFilesService ioService,
             int corePoolSize,
-            int maxPoolSize)
+            int maxPoolSize,
+            ExecutorService processor)
     {
         this.compressionService = compressionService;
         this.lutProvider = lutProvider;
@@ -129,6 +135,7 @@ public class ImageRegionVerticle extends OmeroMsAbstractVerticle {
         this.ioService = ioService;
         this.corePoolSize = corePoolSize;
         this.maxPoolSize = maxPoolSize;
+        this.processor = processor;
     }
 
     /* (non-Javadoc)
@@ -211,7 +218,8 @@ public class ImageRegionVerticle extends OmeroMsAbstractVerticle {
                             maxTileLength,
                             pixelsService,
                             corePoolSize,
-                            maxPoolSize)::renderImageRegion);
+                            maxPoolSize,
+                            processor)::renderImageRegion);
             span.finish();
             if (imageRegion == null) {
                 message.fail(
@@ -282,7 +290,8 @@ public class ImageRegionVerticle extends OmeroMsAbstractVerticle {
                         compressionService,
                         maxTileLength,
                         pixelsService,
-                        iScale)::renderThumbnail);
+                        iScale,
+                        processor)::renderThumbnail);
             if (thumbnail == null) {
                 message.fail(
                         404, "Cannot find Images:" + thumbnailCtx.imageIds);
@@ -347,7 +356,8 @@ public class ImageRegionVerticle extends OmeroMsAbstractVerticle {
                             compressionService,
                             maxTileLength,
                             pixelsService,
-                            iScale)::renderThumbnails);
+                            iScale,
+                            processor)::renderThumbnails);
 
             if (thumbnails == null) {
                 message.fail(404, "Cannot find one or more Images");

--- a/src/main/java/com/glencoesoftware/omero/ms/image/region/ImageRegionVerticle.java
+++ b/src/main/java/com/glencoesoftware/omero/ms/image/region/ImageRegionVerticle.java
@@ -101,6 +101,9 @@ public class ImageRegionVerticle extends OmeroMsAbstractVerticle {
 
     /** Scaling service for thumbnails */
     private final IScale iScale;
+    /** thread pool size for rendering */
+    private final int corePoolSize;
+    private final int maxPoolSize;
 
     /** Original File Service for getting paths */
     private OriginalFilesService ioService;
@@ -114,7 +117,9 @@ public class ImageRegionVerticle extends OmeroMsAbstractVerticle {
             int maxTileLength,
             ZarrPixelsService pixelsService,
             IScale iScale,
-            OriginalFilesService ioService)
+            OriginalFilesService ioService,
+            int corePoolSize,
+            int maxPoolSize)
     {
         this.compressionService = compressionService;
         this.lutProvider = lutProvider;
@@ -122,6 +127,8 @@ public class ImageRegionVerticle extends OmeroMsAbstractVerticle {
         this.pixelsService = pixelsService;
         this.iScale = iScale;
         this.ioService = ioService;
+        this.corePoolSize = corePoolSize;
+        this.maxPoolSize = maxPoolSize;
     }
 
     /* (non-Javadoc)
@@ -202,7 +209,9 @@ public class ImageRegionVerticle extends OmeroMsAbstractVerticle {
                             lutProvider,
                             compressionService,
                             maxTileLength,
-                            pixelsService)::renderImageRegion);
+                            pixelsService,
+                            corePoolSize,
+                            maxPoolSize)::renderImageRegion);
             span.finish();
             if (imageRegion == null) {
                 message.fail(

--- a/src/main/java/com/glencoesoftware/omero/ms/image/region/ThumbnailsRequestHandler.java
+++ b/src/main/java/com/glencoesoftware/omero/ms/image/region/ThumbnailsRequestHandler.java
@@ -87,8 +87,6 @@ public class ThumbnailsRequestHandler extends ImageRegionRequestHandler {
                 compressionSrv,
                 maxTileLength,
                 pixelsService,
-                maxTileLength,
-                maxTileLength,
                 processor);
         this.thumbnailCtx = thumbnailCtx;
         this.iScale = iScale;

--- a/src/main/java/com/glencoesoftware/omero/ms/image/region/ThumbnailsRequestHandler.java
+++ b/src/main/java/com/glencoesoftware/omero/ms/image/region/ThumbnailsRequestHandler.java
@@ -25,6 +25,7 @@ import java.util.Arrays;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
+import java.util.concurrent.ExecutorService;
 import java.util.stream.Collectors;
 
 import org.slf4j.LoggerFactory;
@@ -77,14 +78,18 @@ public class ThumbnailsRequestHandler extends ImageRegionRequestHandler {
             LocalCompress compressionSrv,
             int maxTileLength,
             ZarrPixelsService pixelsService,
-            IScale iScale) {
+            IScale iScale,
+            ExecutorService processor) {
         super(thumbnailCtx,
                 families,
                 renderingModels,
                 lutProvider,
                 compressionSrv,
                 maxTileLength,
-                pixelsService);
+                pixelsService,
+                maxTileLength,
+                maxTileLength,
+                processor);
         this.thumbnailCtx = thumbnailCtx;
         this.iScale = iScale;
     }

--- a/src/main/resources/beanRefContext.xml
+++ b/src/main/resources/beanRefContext.xml
@@ -71,6 +71,8 @@
     <constructor-arg ref="/OMERO/Pixels"/>
     <constructor-arg ref="iscale" />
     <constructor-arg ref="/OMERO/Files"/>
+    <constructor-arg value="${omero.core_pool_size:2}" />
+    <constructor-arg value="${omero.max_pool_size:2}" />
   </bean>
 
   <bean id="omero-ms-shape-mask-verticle"

--- a/src/main/resources/beanRefContext.xml
+++ b/src/main/resources/beanRefContext.xml
@@ -82,8 +82,6 @@
     <constructor-arg ref="/OMERO/Pixels"/>
     <constructor-arg ref="iscale" />
     <constructor-arg ref="/OMERO/Files"/>
-    <constructor-arg value="${omero.core_pool_size:2}" />
-    <constructor-arg value="${omero.max_pool_size:2}" />
     <constructor-arg ref="rendering-thread-pool" />
   </bean>
 

--- a/src/main/resources/beanRefContext.xml
+++ b/src/main/resources/beanRefContext.xml
@@ -61,6 +61,17 @@
   <alias name="${omero.pixeldata.pixels_service:ZarrPixelsService}" alias="/OMERO/Pixels"/>
 
   <bean id="iscale" class="ome.logic.JavaImageScalingService"/>
+  
+  <bean id="rendering-queue" class="java.util.concurrent.LinkedBlockingQueue"/>
+  
+  <bean id="rendering-thread-pool"
+        class="java.util.concurrent.ThreadPoolExecutor">
+    <constructor-arg value="${omero.core_pool_size:16}"/>
+    <constructor-arg value="${omero.max_pool_size:16}"/>
+    <constructor-arg value="600"/> <!-- Keep alive time for threads created beyond core thread pool size -->
+    <constructor-arg type="java.util.concurrent.TimeUnit" value="SECONDS"/>
+    <constructor-arg ref="rendering-queue"/>
+  </bean>
 
   <bean id="omero-ms-image-region-verticle"
         class="com.glencoesoftware.omero.ms.image.region.ImageRegionVerticle"
@@ -73,6 +84,7 @@
     <constructor-arg ref="/OMERO/Files"/>
     <constructor-arg value="${omero.core_pool_size:2}" />
     <constructor-arg value="${omero.max_pool_size:2}" />
+    <constructor-arg ref="rendering-thread-pool" />
   </bean>
 
   <bean id="omero-ms-shape-mask-verticle"

--- a/src/test/java/com/glencoesoftware/omero/ms/image/region/ImageRegionRequestHandlerTest.java
+++ b/src/test/java/com/glencoesoftware/omero/ms/image/region/ImageRegionRequestHandlerTest.java
@@ -24,6 +24,11 @@ import java.awt.Dimension;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.List;
+import java.util.concurrent.BlockingQueue;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.LinkedBlockingQueue;
+import java.util.concurrent.ThreadPoolExecutor;
+import java.util.concurrent.TimeUnit;
 
 import org.junit.Test;
 import org.junit.Assert;
@@ -53,6 +58,9 @@ public class ImageRegionRequestHandlerTest {
         params.add("m", "c");
         params.add("c", "1|0:255$FF0000,2|0:255$00FF00,3|0:255$FF0000");
 
+        BlockingQueue<Runnable> blockingQueue = new LinkedBlockingQueue<Runnable>();
+        ExecutorService processor = new ThreadPoolExecutor(1, 1, 0L, TimeUnit.SECONDS, blockingQueue);
+
         imageRegionCtx = new ImageRegionCtx(params, "");
         reqHandler = new ImageRegionRequestHandler(imageRegionCtx,
                 new ArrayList<Family>(),
@@ -60,7 +68,8 @@ public class ImageRegionRequestHandlerTest {
                 null, //LutProvider lutProvider,
                 null, //LocalCompress compSrv,
                 1024, //maxTileLength,
-                null  //PixelsService
+                null,  //PixelsService
+                processor
         );
     }
 


### PR DESCRIPTION
Requires https://github.com/ome/omero-renderer/pull/37
Fixes #50 

To summarize the above two, previously multiple attempts to render would result in a prodigious number of threads being created.

With this PR, instead of using different, unbounded thread pools for each call to `render`, we use a single shared `ThreadPoolExecutor` which can be configured to limit the number of concurrent rendering tasks which can execute. The `ThreadPoolExecutor` is set up with an unbounded task queue, so there should be no issue with tasks getting dropped, although some might take awhile to process. #160 may be relevant here.

Client experience should not really change with this PR, so testing will involve using e.g. a debugger to analyze the `ThreadPoolExecutor` to make sure the limits are set and threads are being created as expected. 