### PR TITLE
Support v3 omero-zarr-pixel-buffer

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -11,6 +11,11 @@ mainClassName = 'com.glencoesoftware.omero.ms.image.region.OmeroVertxLauncher'
 sourceCompatibility = 1.11
 targetCompatibility = 1.11
 
+ext {
+    jacksonVersion = '2.20.0'
+    zarrJavaVersion = '0.1.1'
+}
+
 repositories {
     mavenCentral()
     mavenLocal()
@@ -61,13 +66,14 @@ dependencies {
     implementation 'io.zipkin.reporter2:zipkin-sender-okhttp3:2.10.0'
     implementation 'ch.qos.logback:logback-classic:1.3.15'
     implementation 'org.slf4j:log4j-over-slf4j:1.7.32'
-    implementation 'com.glencoesoftware.omero:omero-zarr-pixel-buffer:0.6.1'
+    implementation "dev.zarr:zarr-java:${zarrJavaVersion}"
+    implementation 'com.glencoesoftware.omero:omero-zarr-pixel-buffer:0.6.2-SNAPSHOT'
     implementation 'com.glencoesoftware.omero:omero-ms-core:0.11.0'
     implementation 'io.vertx:vertx-web:4.5.16'
     implementation 'io.vertx:vertx-config:4.5.16'
     implementation 'io.vertx:vertx-config-yaml:4.5.16'
     implementation 'io.vertx:vertx-micrometer-metrics:4.5.16'
-    implementation 'com.fasterxml.jackson.core:jackson-databind:2.16.1'
+    implementation "com.fasterxml.jackson.core:jackson-databind:${jacksonVersion}"
     implementation 'io.micrometer:micrometer-registry-prometheus:1.3.0'
     implementation 'org.openmicroscopy:omero-blitz:5.8.4'
     implementation 'io.prometheus.jmx:collector:0.12.0'
@@ -77,9 +83,6 @@ dependencies {
     implementation 'com.zeroc:icegrid:3.6.5'
     implementation 'com.google.code.gson:gson:2.8.6'
     implementation 'com.github.ben-manes.caffeine:caffeine:3.1.8'
-    implementation 'dev.zarr:jzarr:0.4.2'
-    implementation 'org.lasersonlab:s3fs:2.2.3'
-    implementation 'com.amazonaws:aws-java-sdk-s3:1.12.659'
     implementation 'org.apache.tika:tika-core:1.28.5'
 
     testImplementation("junit:junit:4.12")

--- a/build.gradle
+++ b/build.gradle
@@ -4,7 +4,7 @@ plugins {
 }
 
 group = 'com.glencoesoftware.omero'
-version = '0.13.0'
+version = '0.14.0-SNAPSHOT'
 
 mainClassName = 'com.glencoesoftware.omero.ms.image.region.OmeroVertxLauncher'
 
@@ -13,7 +13,7 @@ targetCompatibility = 1.11
 
 ext {
     jacksonVersion = '2.20.0'
-    zarrJavaVersion = '0.1.1'
+    zarrJavaVersion = '0.1.3'
 }
 
 repositories {
@@ -67,7 +67,7 @@ dependencies {
     implementation 'ch.qos.logback:logback-classic:1.3.15'
     implementation 'org.slf4j:log4j-over-slf4j:1.7.32'
     implementation "dev.zarr:zarr-java:${zarrJavaVersion}"
-    implementation 'com.glencoesoftware.omero:omero-zarr-pixel-buffer:0.6.2-SNAPSHOT'
+    implementation 'com.glencoesoftware.omero:omero-zarr-pixel-buffer:0.7.0-SNAPSHOT'
     implementation 'com.glencoesoftware.omero:omero-ms-core:0.11.0'
     implementation 'io.vertx:vertx-web:4.5.16'
     implementation 'io.vertx:vertx-config:4.5.16'

--- a/build.gradle
+++ b/build.gradle
@@ -67,7 +67,7 @@ dependencies {
     implementation 'ch.qos.logback:logback-classic:1.3.15'
     implementation 'org.slf4j:log4j-over-slf4j:1.7.32'
     implementation "dev.zarr:zarr-java:${zarrJavaVersion}"
-    implementation 'com.glencoesoftware.omero:omero-zarr-pixel-buffer:0.7.0-SNAPSHOT'
+    implementation 'com.glencoesoftware.omero:omero-zarr-pixel-buffer:0.7.0-rc1'
     implementation 'com.glencoesoftware.omero:omero-ms-core:0.11.0'
     implementation 'io.vertx:vertx-web:4.5.16'
     implementation 'io.vertx:vertx-config:4.5.16'

--- a/build.gradle
+++ b/build.gradle
@@ -20,8 +20,8 @@ repositories {
     mavenCentral()
     mavenLocal()
     maven {
-        name 'Unidata'
-        url 'https://artifacts.glencoesoftware.com/artifactory/unidata-releases'
+        name = 'Unidata'
+        url = 'https://artifacts.unidata.ucar.edu/repository/unidata-releases/'
     }
     maven {
         url 'https://artifacts.glencoesoftware.com/artifactory/ome.releases'

--- a/src/main/java/com/glencoesoftware/omero/ms/image/region/ShapeMaskRequestHandler.java
+++ b/src/main/java/com/glencoesoftware/omero/ms/image/region/ShapeMaskRequestHandler.java
@@ -21,6 +21,8 @@ package com.glencoesoftware.omero.ms.image.region;
 import com.glencoesoftware.omero.zarr.ZarrPixelBuffer;
 import com.glencoesoftware.omero.zarr.ZarrPixelsService;
 
+import dev.zarr.zarrjava.ZarrException;
+
 import java.awt.Point;
 import java.awt.image.BufferedImage;
 import java.awt.image.ColorModel;
@@ -36,6 +38,7 @@ import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.Optional;
+import java.net.URISyntaxException;
 
 import javax.imageio.ImageIO;
 
@@ -419,7 +422,8 @@ public class ShapeMaskRequestHandler {
      * @throws ApiUsageException
      */
     private byte[] getShapeMaskBytes(Mask mask)
-            throws ApiUsageException, IOException {
+            throws ApiUsageException, IOException, URISyntaxException,
+            ZarrException {
         String uri = getLabelUri(mask);
         if (uri == null) {
             return mask.getBytes();

--- a/src/test/java/com/glencoesoftware/omero/ms/image/region/ImageDataRequestHandlerTest.java
+++ b/src/test/java/com/glencoesoftware/omero/ms/image/region/ImageDataRequestHandlerTest.java
@@ -20,9 +20,11 @@ package com.glencoesoftware.omero.ms.image.region;
 
 import com.glencoesoftware.omero.zarr.ZarrPixelBuffer;
 import com.glencoesoftware.omero.zarr.ZarrPixelsService;
+import com.glencoesoftware.omero.zarr.ZarrStore;
 
 import java.io.File;
 import java.io.IOException;
+import java.net.URISyntaxException;
 import java.nio.file.Files;
 import java.nio.file.Path;
 import java.nio.file.Paths;
@@ -87,7 +89,9 @@ import static omero.rtypes.rtime;
 import static org.mockito.Mockito.spy;
 import static org.mockito.Mockito.when;
 
-import com.bc.zarr.ZarrGroup;
+import dev.zarr.zarrjava.v2.Group;
+import dev.zarr.zarrjava.core.Attributes;
+import dev.zarr.zarrjava.ZarrException;
 import com.github.benmanes.caffeine.cache.Caffeine;
 import com.glencoesoftware.bioformats2raw.Converter;
 
@@ -401,13 +405,14 @@ public class ImageDataRequestHandlerTest {
         return rdef;
     }
 
-    public void createPixelBuffer() throws IOException, ApiUsageException {
+    public void createPixelBuffer() throws IOException, ApiUsageException,
+            URISyntaxException, ZarrException {
         Path output = writeTestZarr(
                 PIXELS_SIZE_T, PIXELS_SIZE_C, PIXELS_SIZE_Z,
                 PIXELS_SIZE_Y, PIXELS_SIZE_X, PIX_TYPE_STR, RES_LVL_COUNT);
         pixelBuffer = new ZarrPixelBuffer((ome.model.core.Pixels)
                 new IceMapper().reverse(image.getPrimaryPixels()),
-                output.resolve("0"), 1024, 1024,
+                new ZarrStore(output.resolve("0").toString()), 1024, 1024,
                 Caffeine.newBuilder()
                     .maximumSize(0)
                     .buildAsync(ZarrPixelsService::getZarrMetadata),
@@ -417,7 +422,8 @@ public class ImageDataRequestHandlerTest {
     }
 
     @Before
-    public void setup() throws IOException, ApiUsageException {
+    public void setup() throws IOException, ApiUsageException,
+            URISyntaxException, ZarrException {
         setupStdJson();
 
         Event creationEvent = new EventI();
@@ -663,7 +669,7 @@ public class ImageDataRequestHandlerTest {
             int sizeY,
             int sizeX,
             String pixelType,
-            int resolutions) throws IOException {
+            int resolutions) throws IOException, ZarrException {
         Path input = fake(
                 "sizeT", Integer.toString(sizeT),
                 "sizeC", Integer.toString(sizeC),
@@ -674,19 +680,6 @@ public class ImageDataRequestHandlerTest {
                 "resolutions", Integer.toString(resolutions));
         Path output = tmpDir.getRoot().toPath().resolve("output.zarr");
         assertBioFormats2Raw(input, output);
-        List<Object> msArray = new ArrayList<>();
-        Map<String, Object> msData = new HashMap<>();
-        Map<String, Object> msMetadata = new HashMap<>();
-        msMetadata.put("method", "loci.common.image.SimpleImageScaler");
-        msMetadata.put("version", "Bio-Formats 6.5.1");
-        msData.put("metadata", msMetadata);
-        msData.put("datasets", getDatasets(resolutions));
-        msData.put("version", "0.1");
-        msArray.add(msData);
-        ZarrGroup z = ZarrGroup.open(output.resolve("0"));
-        Map<String,Object> attrs = new HashMap<String, Object>();
-        attrs.put("multiscales", msArray);
-        z.writeAttributes(attrs);
         return output;
     }
 
@@ -997,7 +990,7 @@ public class ImageDataRequestHandlerTest {
 
     @Test
     public void testImageDataPixelRange()
-            throws IOException, ApiUsageException {
+            throws IOException, ApiUsageException, URISyntaxException, ZarrException {
         ImageDataCtx ctx = new ImageDataCtx();
         ctx.imageId = IMAGE_ID;
         ImageDataRequestHandler reqHandler = new ImageDataRequestHandler(

--- a/src/test/java/com/glencoesoftware/omero/ms/image/region/ImageDataRequestHandlerTest.java
+++ b/src/test/java/com/glencoesoftware/omero/ms/image/region/ImageDataRequestHandlerTest.java
@@ -89,8 +89,6 @@ import static omero.rtypes.rtime;
 import static org.mockito.Mockito.spy;
 import static org.mockito.Mockito.when;
 
-import dev.zarr.zarrjava.v2.Group;
-import dev.zarr.zarrjava.core.Attributes;
 import dev.zarr.zarrjava.ZarrException;
 import com.github.benmanes.caffeine.cache.Caffeine;
 import com.glencoesoftware.bioformats2raw.Converter;


### PR DESCRIPTION
Opening as a draft.

This branch requires https://github.com/ome/omero-zarr-pixel-buffer/pull/15.

All this branch does is make the small changes necessary to use the linked branch of omero-zarr-pixel-buffer, which contains support for zarr v3 images. With these changes, it should be possible to import an image using https://github.com/glencoesoftware/omero-importer-ngff/pull/49 and then view tiles with `/render_image_region`