### PR TITLE
Bump com.glencoesoftware.omero:omero-zarr-pixel-buffer to 0.7.0-rc3

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -11,11 +11,6 @@ mainClassName = 'com.glencoesoftware.omero.ms.image.region.OmeroVertxLauncher'
 sourceCompatibility = 1.11
 targetCompatibility = 1.11
 
-ext {
-    jacksonVersion = '2.20.0'
-    zarrJavaVersion = '0.1.3'
-}
-
 repositories {
     mavenCentral()
     mavenLocal()
@@ -66,16 +61,16 @@ dependencies {
     implementation 'io.zipkin.reporter2:zipkin-sender-okhttp3:2.10.0'
     implementation 'ch.qos.logback:logback-classic:1.3.15'
     implementation 'org.slf4j:log4j-over-slf4j:1.7.32'
-    implementation "dev.zarr:zarr-java:${zarrJavaVersion}"
-    implementation 'com.glencoesoftware.omero:omero-zarr-pixel-buffer:0.7.0-rc1'
+    implementation "dev.zarr:zarr-java:0.2.0"
+    implementation 'com.glencoesoftware.omero:omero-zarr-pixel-buffer:0.7.0-rc3'
     implementation 'com.glencoesoftware.omero:omero-ms-core:0.11.0'
     implementation 'io.vertx:vertx-web:4.5.16'
     implementation 'io.vertx:vertx-config:4.5.16'
     implementation 'io.vertx:vertx-config-yaml:4.5.16'
     implementation 'io.vertx:vertx-micrometer-metrics:4.5.16'
-    implementation "com.fasterxml.jackson.core:jackson-databind:${jacksonVersion}"
+    implementation "com.fasterxml.jackson.core:jackson-databind:2.20.0"
     implementation 'io.micrometer:micrometer-registry-prometheus:1.3.0'
-    implementation 'org.openmicroscopy:omero-blitz:5.8.4'
+    implementation 'org.openmicroscopy:omero-blitz:5.8.5'
     implementation 'io.prometheus.jmx:collector:0.12.0'
     implementation 'io.prometheus:simpleclient_hotspot:0.8.0'
     implementation 'info.picocli:picocli:4.1.4'


### PR DESCRIPTION
See https://github.com/glencoesoftware/omero-zarr-pixel-buffer/releases/tag/v0.7.0-rc2 and https://github.com/glencoesoftware/omero-zarr-pixel-buffer/releases/tag/v0.7.0-rc3 

Also bumps org.openmicroscopy:omero-blitz to 5.8.5 and dev.zarr:zarr-java to 0.2.0